### PR TITLE
[Umi] Add support for mintToCollectionV1

### DIFF
--- a/clients/js/src/generated/instructions/burn.ts
+++ b/clients/js/src/generated/instructions/burn.ts
@@ -31,7 +31,7 @@ import { addAccountMeta, addObjectProperty } from '../shared';
 
 // Accounts.
 export type BurnInstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
@@ -114,9 +114,9 @@ export function burn(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, false] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, false] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -165,7 +165,7 @@ export function burn(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafOwner, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);

--- a/clients/js/src/generated/instructions/burn.ts
+++ b/clients/js/src/generated/instructions/burn.ts
@@ -33,7 +33,7 @@ import { addAccountMeta, addObjectProperty } from '../shared';
 export type BurnInstructionAccounts = {
   treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
-  leafDelegate: PublicKey | Pda;
+  leafDelegate?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
@@ -108,7 +108,6 @@ export function burn(
   // Resolved inputs.
   const resolvedAccounts = {
     leafOwner: [input.leafOwner, false] as const,
-    leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
   };
   const resolvingArgs = {};
@@ -123,6 +122,13 @@ export function burn(
           }),
           false,
         ] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'leafDelegate',
+    input.leafDelegate
+      ? ([input.leafDelegate, false] as const)
+      : ([input.leafOwner, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/cancelRedeem.ts
+++ b/clients/js/src/generated/instructions/cancelRedeem.ts
@@ -29,7 +29,7 @@ import { addAccountMeta, addObjectProperty } from '../shared';
 
 // Accounts.
 export type CancelRedeemInstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   leafOwner: Signer;
   merkleTree: PublicKey | Pda;
   voucher: PublicKey | Pda;
@@ -102,9 +102,9 @@ export function cancelRedeem(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, false] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, false] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -153,7 +153,7 @@ export function cancelRedeem(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafOwner, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);
   addAccountMeta(keys, signers, resolvedAccounts.voucher, false);

--- a/clients/js/src/generated/instructions/createTreeConfig.ts
+++ b/clients/js/src/generated/instructions/createTreeConfig.ts
@@ -35,7 +35,7 @@ import { addAccountMeta, addObjectProperty } from '../shared';
 
 // Accounts.
 export type CreateTreeConfigInstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
   treeCreator?: Signer;
@@ -125,9 +125,9 @@ export function createTreeConfig(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, true] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, true] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -190,7 +190,7 @@ export function createTreeConfig(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);
   addAccountMeta(keys, signers, resolvedAccounts.payer, false);
   addAccountMeta(keys, signers, resolvedAccounts.treeCreator, false);

--- a/clients/js/src/generated/instructions/delegate.ts
+++ b/clients/js/src/generated/instructions/delegate.ts
@@ -31,7 +31,7 @@ import { addAccountMeta, addObjectProperty } from '../shared';
 
 // Accounts.
 export type DelegateInstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   leafOwner: Signer;
   previousLeafDelegate: PublicKey | Pda;
   newLeafDelegate: PublicKey | Pda;
@@ -117,9 +117,9 @@ export function delegate(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, false] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, false] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -168,7 +168,7 @@ export function delegate(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafOwner, false);
   addAccountMeta(keys, signers, resolvedAccounts.previousLeafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.newLeafDelegate, false);

--- a/clients/js/src/generated/instructions/mintToCollectionV1.ts
+++ b/clients/js/src/generated/instructions/mintToCollectionV1.ts
@@ -38,7 +38,7 @@ export type MintToCollectionV1InstructionAccounts = {
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
-  treeDelegate: Signer;
+  treeCreatorOrDelegate: Signer;
   collectionAuthority: Signer;
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
@@ -124,7 +124,7 @@ export function mintToCollectionV1(
     leafOwner: [input.leafOwner, false] as const,
     leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
-    treeDelegate: [input.treeDelegate, false] as const,
+    treeCreatorOrDelegate: [input.treeCreatorOrDelegate, false] as const,
     collectionAuthority: [input.collectionAuthority, false] as const,
     collectionAuthorityRecordPda: [
       input.collectionAuthorityRecordPda,
@@ -223,7 +223,7 @@ export function mintToCollectionV1(
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);
   addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.treeDelegate, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeCreatorOrDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.collectionAuthority, false);
   addAccountMeta(
     keys,

--- a/clients/js/src/generated/instructions/mintToCollectionV1.ts
+++ b/clients/js/src/generated/instructions/mintToCollectionV1.ts
@@ -54,11 +54,11 @@ export type MintToCollectionV1InstructionAccounts = {
 // Data.
 export type MintToCollectionV1InstructionData = {
   discriminator: Array<number>;
-  metadataArgs: MetadataArgs;
+  message: MetadataArgs;
 };
 
 export type MintToCollectionV1InstructionDataArgs = {
-  metadataArgs: MetadataArgsArgs;
+  message: MetadataArgsArgs;
 };
 
 /** @deprecated Use `getMintToCollectionV1InstructionDataSerializer()` without any argument instead. */
@@ -86,7 +86,7 @@ export function getMintToCollectionV1InstructionDataSerializer(
     struct<MintToCollectionV1InstructionData>(
       [
         ['discriminator', array(u8(), { size: 8 })],
-        ['metadataArgs', getMetadataArgsSerializer()],
+        ['message', getMetadataArgsSerializer()],
       ],
       { description: 'MintToCollectionV1InstructionData' }
     ),

--- a/clients/js/src/generated/instructions/mintToCollectionV1.ts
+++ b/clients/js/src/generated/instructions/mintToCollectionV1.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata';
 import {
   AccountMeta,
   Context,
@@ -42,7 +43,7 @@ export type MintToCollectionV1InstructionAccounts = {
   collectionAuthority: Signer;
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
-  collectionMetadata: PublicKey | Pda;
+  collectionMetadata?: PublicKey | Pda;
   editionAccount: PublicKey | Pda;
   bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
@@ -129,7 +130,6 @@ export function mintToCollectionV1(
       false,
     ] as const,
     collectionMint: [input.collectionMint, false] as const,
-    collectionMetadata: [input.collectionMetadata, true] as const,
     editionAccount: [input.editionAccount, false] as const,
   };
   const resolvingArgs = {};
@@ -165,6 +165,18 @@ export function mintToCollectionV1(
     input.treeCreatorOrDelegate
       ? ([input.treeCreatorOrDelegate, false] as const)
       : ([context.identity, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionMetadata',
+    input.collectionMetadata
+      ? ([input.collectionMetadata, true] as const)
+      : ([
+          findMetadataPda(context, {
+            mint: publicKey(input.collectionMint, false),
+          }),
+          true,
+        ] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/mintToCollectionV1.ts
+++ b/clients/js/src/generated/instructions/mintToCollectionV1.ts
@@ -44,7 +44,7 @@ export type MintToCollectionV1InstructionAccounts = {
   collectionMint: PublicKey | Pda;
   collectionMetadata: PublicKey | Pda;
   editionAccount: PublicKey | Pda;
-  bubblegumSigner: PublicKey | Pda;
+  bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
   tokenMetadataProgram?: PublicKey | Pda;
@@ -133,7 +133,6 @@ export function mintToCollectionV1(
     collectionMint: [input.collectionMint, false] as const,
     collectionMetadata: [input.collectionMetadata, true] as const,
     editionAccount: [input.editionAccount, false] as const,
-    bubblegumSigner: [input.bubblegumSigner, false] as const,
   };
   const resolvingArgs = {};
   addObjectProperty(
@@ -154,6 +153,16 @@ export function mintToCollectionV1(
     input.payer
       ? ([input.payer, false] as const)
       : ([context.payer, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'bubblegumSigner',
+    input.bubblegumSigner
+      ? ([input.bubblegumSigner, false] as const)
+      : ([
+          publicKey('4ewWZC5gT6TGpm5LZNDs9wVonfUT2q5PP5sc9kVbwMAK'),
+          false,
+        ] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/mintToCollectionV1.ts
+++ b/clients/js/src/generated/instructions/mintToCollectionV1.ts
@@ -43,8 +43,8 @@ export type MintToCollectionV1InstructionAccounts = {
   merkleTree: PublicKey | Pda;
   payer?: Signer;
   treeCreatorOrDelegate?: Signer;
-  collectionAuthority: Signer;
-  collectionAuthorityRecordPda: PublicKey | Pda;
+  collectionAuthority?: Signer;
+  collectionAuthorityRecordPda?: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;
   collectionEdition?: PublicKey | Pda;
@@ -127,11 +127,6 @@ export function mintToCollectionV1(
   const resolvedAccounts = {
     leafOwner: [input.leafOwner, false] as const,
     merkleTree: [input.merkleTree, true] as const,
-    collectionAuthority: [input.collectionAuthority, false] as const,
-    collectionAuthorityRecordPda: [
-      input.collectionAuthorityRecordPda,
-      false,
-    ] as const,
     collectionMint: [input.collectionMint, false] as const,
   };
   const resolvingArgs = {};
@@ -167,6 +162,20 @@ export function mintToCollectionV1(
     input.treeCreatorOrDelegate
       ? ([input.treeCreatorOrDelegate, false] as const)
       : ([context.identity, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionAuthority',
+    input.collectionAuthority
+      ? ([input.collectionAuthority, false] as const)
+      : ([context.identity, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionAuthorityRecordPda',
+    input.collectionAuthorityRecordPda
+      ? ([input.collectionAuthorityRecordPda, false] as const)
+      : ([programId, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/mintToCollectionV1.ts
+++ b/clients/js/src/generated/instructions/mintToCollectionV1.ts
@@ -44,7 +44,7 @@ export type MintToCollectionV1InstructionAccounts = {
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;
-  editionAccount: PublicKey | Pda;
+  collectionEdition: PublicKey | Pda;
   bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
@@ -130,7 +130,7 @@ export function mintToCollectionV1(
       false,
     ] as const,
     collectionMint: [input.collectionMint, false] as const,
-    editionAccount: [input.editionAccount, false] as const,
+    collectionEdition: [input.collectionEdition, false] as const,
   };
   const resolvingArgs = {};
   addObjectProperty(
@@ -257,7 +257,7 @@ export function mintToCollectionV1(
   );
   addAccountMeta(keys, signers, resolvedAccounts.collectionMint, false);
   addAccountMeta(keys, signers, resolvedAccounts.collectionMetadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.editionAccount, false);
+  addAccountMeta(keys, signers, resolvedAccounts.collectionEdition, false);
   addAccountMeta(keys, signers, resolvedAccounts.bubblegumSigner, false);
   addAccountMeta(keys, signers, resolvedAccounts.logWrapper, false);
   addAccountMeta(keys, signers, resolvedAccounts.compressionProgram, false);

--- a/clients/js/src/generated/instructions/mintToCollectionV1.ts
+++ b/clients/js/src/generated/instructions/mintToCollectionV1.ts
@@ -35,7 +35,7 @@ import {
 export type MintToCollectionV1InstructionAccounts = {
   treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
-  leafDelegate: PublicKey | Pda;
+  leafDelegate?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
   treeCreatorOrDelegate?: Signer;
@@ -122,7 +122,6 @@ export function mintToCollectionV1(
   // Resolved inputs.
   const resolvedAccounts = {
     leafOwner: [input.leafOwner, false] as const,
-    leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
     collectionAuthority: [input.collectionAuthority, false] as const,
     collectionAuthorityRecordPda: [
@@ -145,6 +144,13 @@ export function mintToCollectionV1(
           }),
           true,
         ] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'leafDelegate',
+    input.leafDelegate
+      ? ([input.leafDelegate, false] as const)
+      : ([input.leafOwner, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/mintToCollectionV1.ts
+++ b/clients/js/src/generated/instructions/mintToCollectionV1.ts
@@ -33,7 +33,7 @@ import {
 
 // Accounts.
 export type MintToCollectionV1InstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
@@ -138,9 +138,9 @@ export function mintToCollectionV1(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, true] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, true] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -209,7 +209,7 @@ export function mintToCollectionV1(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafOwner, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);

--- a/clients/js/src/generated/instructions/mintToCollectionV1.ts
+++ b/clients/js/src/generated/instructions/mintToCollectionV1.ts
@@ -38,7 +38,7 @@ export type MintToCollectionV1InstructionAccounts = {
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
-  treeCreatorOrDelegate: Signer;
+  treeCreatorOrDelegate?: Signer;
   collectionAuthority: Signer;
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
@@ -106,7 +106,7 @@ export type MintToCollectionV1InstructionArgs =
 
 // Instruction.
 export function mintToCollectionV1(
-  context: Pick<Context, 'programs' | 'eddsa' | 'payer'>,
+  context: Pick<Context, 'programs' | 'eddsa' | 'identity' | 'payer'>,
   input: MintToCollectionV1InstructionAccounts &
     MintToCollectionV1InstructionArgs
 ): TransactionBuilder {
@@ -124,7 +124,6 @@ export function mintToCollectionV1(
     leafOwner: [input.leafOwner, false] as const,
     leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
-    treeCreatorOrDelegate: [input.treeCreatorOrDelegate, false] as const,
     collectionAuthority: [input.collectionAuthority, false] as const,
     collectionAuthorityRecordPda: [
       input.collectionAuthorityRecordPda,
@@ -153,6 +152,13 @@ export function mintToCollectionV1(
     input.payer
       ? ([input.payer, false] as const)
       : ([context.payer, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'treeCreatorOrDelegate',
+    input.treeCreatorOrDelegate
+      ? ([input.treeCreatorOrDelegate, false] as const)
+      : ([context.identity, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/mintToCollectionV1.ts
+++ b/clients/js/src/generated/instructions/mintToCollectionV1.ts
@@ -6,7 +6,10 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata';
+import {
+  findMasterEditionPda,
+  findMetadataPda,
+} from '@metaplex-foundation/mpl-token-metadata';
 import {
   AccountMeta,
   Context,
@@ -44,7 +47,7 @@ export type MintToCollectionV1InstructionAccounts = {
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;
-  collectionEdition: PublicKey | Pda;
+  collectionEdition?: PublicKey | Pda;
   bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
@@ -130,7 +133,6 @@ export function mintToCollectionV1(
       false,
     ] as const,
     collectionMint: [input.collectionMint, false] as const,
-    collectionEdition: [input.collectionEdition, false] as const,
   };
   const resolvingArgs = {};
   addObjectProperty(
@@ -176,6 +178,18 @@ export function mintToCollectionV1(
             mint: publicKey(input.collectionMint, false),
           }),
           true,
+        ] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionEdition',
+    input.collectionEdition
+      ? ([input.collectionEdition, false] as const)
+      : ([
+          findMasterEditionPda(context, {
+            mint: publicKey(input.collectionMint, false),
+          }),
+          false,
         ] as const)
   );
   addObjectProperty(

--- a/clients/js/src/generated/instructions/mintV1.ts
+++ b/clients/js/src/generated/instructions/mintV1.ts
@@ -33,7 +33,7 @@ import {
 
 // Accounts.
 export type MintV1InstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
   leafDelegate?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
@@ -103,9 +103,9 @@ export function mintV1(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, true] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, true] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -175,7 +175,7 @@ export function mintV1(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafOwner, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);

--- a/clients/js/src/generated/instructions/redeem.ts
+++ b/clients/js/src/generated/instructions/redeem.ts
@@ -33,7 +33,7 @@ import { addAccountMeta, addObjectProperty } from '../shared';
 export type RedeemInstructionAccounts = {
   treeConfig?: PublicKey | Pda;
   leafOwner: Signer;
-  leafDelegate: PublicKey | Pda;
+  leafDelegate?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   voucher: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
@@ -109,7 +109,6 @@ export function redeem(
   // Resolved inputs.
   const resolvedAccounts = {
     leafOwner: [input.leafOwner, true] as const,
-    leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
     voucher: [input.voucher, true] as const,
   };
@@ -125,6 +124,13 @@ export function redeem(
           }),
           false,
         ] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'leafDelegate',
+    input.leafDelegate
+      ? ([input.leafDelegate, false] as const)
+      : ([input.leafOwner, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/redeem.ts
+++ b/clients/js/src/generated/instructions/redeem.ts
@@ -31,7 +31,7 @@ import { addAccountMeta, addObjectProperty } from '../shared';
 
 // Accounts.
 export type RedeemInstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   leafOwner: Signer;
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
@@ -116,9 +116,9 @@ export function redeem(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, false] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, false] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -167,7 +167,7 @@ export function redeem(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafOwner, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);

--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata';
 import {
   AccountMeta,
   Context,
@@ -46,7 +47,7 @@ export type SetAndVerifyCollectionInstructionAccounts = {
   collectionAuthority: Signer;
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
-  collectionMetadata: PublicKey | Pda;
+  collectionMetadata?: PublicKey | Pda;
   editionAccount: PublicKey | Pda;
   bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
@@ -151,7 +152,6 @@ export function setAndVerifyCollection(
       false,
     ] as const,
     collectionMint: [input.collectionMint, false] as const,
-    collectionMetadata: [input.collectionMetadata, true] as const,
     editionAccount: [input.editionAccount, false] as const,
   };
   const resolvingArgs = {};
@@ -187,6 +187,18 @@ export function setAndVerifyCollection(
     input.treeCreatorOrDelegate
       ? ([input.treeCreatorOrDelegate, false] as const)
       : ([context.identity.publicKey, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionMetadata',
+    input.collectionMetadata
+      ? ([input.collectionMetadata, true] as const)
+      : ([
+          findMetadataPda(context, {
+            mint: publicKey(input.collectionMint, false),
+          }),
+          true,
+        ] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -48,7 +48,7 @@ export type SetAndVerifyCollectionInstructionAccounts = {
   collectionMint: PublicKey | Pda;
   collectionMetadata: PublicKey | Pda;
   editionAccount: PublicKey | Pda;
-  bubblegumSigner: PublicKey | Pda;
+  bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
   tokenMetadataProgram?: PublicKey | Pda;
@@ -155,7 +155,6 @@ export function setAndVerifyCollection(
     collectionMint: [input.collectionMint, false] as const,
     collectionMetadata: [input.collectionMetadata, true] as const,
     editionAccount: [input.editionAccount, false] as const,
-    bubblegumSigner: [input.bubblegumSigner, false] as const,
   };
   const resolvingArgs = {};
   addObjectProperty(
@@ -176,6 +175,16 @@ export function setAndVerifyCollection(
     input.payer
       ? ([input.payer, false] as const)
       : ([context.payer, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'bubblegumSigner',
+    input.bubblegumSigner
+      ? ([input.bubblegumSigner, false] as const)
+      : ([
+          publicKey('4ewWZC5gT6TGpm5LZNDs9wVonfUT2q5PP5sc9kVbwMAK'),
+          false,
+        ] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -42,7 +42,7 @@ export type SetAndVerifyCollectionInstructionAccounts = {
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
-  treeDelegate: PublicKey | Pda;
+  treeCreatorOrDelegate: PublicKey | Pda;
   collectionAuthority: Signer;
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
@@ -146,7 +146,7 @@ export function setAndVerifyCollection(
     leafOwner: [input.leafOwner, false] as const,
     leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
-    treeDelegate: [input.treeDelegate, false] as const,
+    treeCreatorOrDelegate: [input.treeCreatorOrDelegate, false] as const,
     collectionAuthority: [input.collectionAuthority, false] as const,
     collectionAuthorityRecordPda: [
       input.collectionAuthorityRecordPda,
@@ -245,7 +245,7 @@ export function setAndVerifyCollection(
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);
   addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.treeDelegate, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeCreatorOrDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.collectionAuthority, false);
   addAccountMeta(
     keys,

--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -39,7 +39,7 @@ import {
 export type SetAndVerifyCollectionInstructionAccounts = {
   treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
-  leafDelegate: PublicKey | Pda;
+  leafDelegate?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
   treeCreatorOrDelegate?: PublicKey | Pda;
@@ -144,7 +144,6 @@ export function setAndVerifyCollection(
   // Resolved inputs.
   const resolvedAccounts = {
     leafOwner: [input.leafOwner, false] as const,
-    leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
     collectionAuthority: [input.collectionAuthority, false] as const,
     collectionAuthorityRecordPda: [
@@ -167,6 +166,13 @@ export function setAndVerifyCollection(
           }),
           false,
         ] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'leafDelegate',
+    input.leafDelegate
+      ? ([input.leafDelegate, false] as const)
+      : ([input.leafOwner, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -42,7 +42,7 @@ export type SetAndVerifyCollectionInstructionAccounts = {
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
-  treeCreatorOrDelegate: PublicKey | Pda;
+  treeCreatorOrDelegate?: PublicKey | Pda;
   collectionAuthority: Signer;
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
@@ -128,7 +128,7 @@ export type SetAndVerifyCollectionInstructionArgs =
 
 // Instruction.
 export function setAndVerifyCollection(
-  context: Pick<Context, 'programs' | 'eddsa' | 'payer'>,
+  context: Pick<Context, 'programs' | 'eddsa' | 'identity' | 'payer'>,
   input: SetAndVerifyCollectionInstructionAccounts &
     SetAndVerifyCollectionInstructionArgs
 ): TransactionBuilder {
@@ -146,7 +146,6 @@ export function setAndVerifyCollection(
     leafOwner: [input.leafOwner, false] as const,
     leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
-    treeCreatorOrDelegate: [input.treeCreatorOrDelegate, false] as const,
     collectionAuthority: [input.collectionAuthority, false] as const,
     collectionAuthorityRecordPda: [
       input.collectionAuthorityRecordPda,
@@ -175,6 +174,13 @@ export function setAndVerifyCollection(
     input.payer
       ? ([input.payer, false] as const)
       : ([context.payer, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'treeCreatorOrDelegate',
+    input.treeCreatorOrDelegate
+      ? ([input.treeCreatorOrDelegate, false] as const)
+      : ([context.identity.publicKey, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -6,7 +6,10 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata';
+import {
+  findMasterEditionPda,
+  findMetadataPda,
+} from '@metaplex-foundation/mpl-token-metadata';
 import {
   AccountMeta,
   Context,
@@ -48,7 +51,7 @@ export type SetAndVerifyCollectionInstructionAccounts = {
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;
-  collectionEdition: PublicKey | Pda;
+  collectionEdition?: PublicKey | Pda;
   bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
@@ -152,7 +155,6 @@ export function setAndVerifyCollection(
       false,
     ] as const,
     collectionMint: [input.collectionMint, false] as const,
-    collectionEdition: [input.collectionEdition, false] as const,
   };
   const resolvingArgs = {};
   addObjectProperty(
@@ -198,6 +200,18 @@ export function setAndVerifyCollection(
             mint: publicKey(input.collectionMint, false),
           }),
           true,
+        ] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionEdition',
+    input.collectionEdition
+      ? ([input.collectionEdition, false] as const)
+      : ([
+          findMasterEditionPda(context, {
+            mint: publicKey(input.collectionMint, false),
+          }),
+          false,
         ] as const)
   );
   addObjectProperty(

--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -47,8 +47,8 @@ export type SetAndVerifyCollectionInstructionAccounts = {
   merkleTree: PublicKey | Pda;
   payer?: Signer;
   treeCreatorOrDelegate?: PublicKey | Pda;
-  collectionAuthority: Signer;
-  collectionAuthorityRecordPda: PublicKey | Pda;
+  collectionAuthority?: Signer;
+  collectionAuthorityRecordPda?: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;
   collectionEdition?: PublicKey | Pda;
@@ -149,11 +149,6 @@ export function setAndVerifyCollection(
   const resolvedAccounts = {
     leafOwner: [input.leafOwner, false] as const,
     merkleTree: [input.merkleTree, true] as const,
-    collectionAuthority: [input.collectionAuthority, false] as const,
-    collectionAuthorityRecordPda: [
-      input.collectionAuthorityRecordPda,
-      false,
-    ] as const,
     collectionMint: [input.collectionMint, false] as const,
   };
   const resolvingArgs = {};
@@ -189,6 +184,20 @@ export function setAndVerifyCollection(
     input.treeCreatorOrDelegate
       ? ([input.treeCreatorOrDelegate, false] as const)
       : ([context.identity.publicKey, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionAuthority',
+    input.collectionAuthority
+      ? ([input.collectionAuthority, false] as const)
+      : ([context.identity, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionAuthorityRecordPda',
+    input.collectionAuthorityRecordPda
+      ? ([input.collectionAuthorityRecordPda, false] as const)
+      : ([programId, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -48,7 +48,7 @@ export type SetAndVerifyCollectionInstructionAccounts = {
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;
-  editionAccount: PublicKey | Pda;
+  collectionEdition: PublicKey | Pda;
   bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
@@ -152,7 +152,7 @@ export function setAndVerifyCollection(
       false,
     ] as const,
     collectionMint: [input.collectionMint, false] as const,
-    editionAccount: [input.editionAccount, false] as const,
+    collectionEdition: [input.collectionEdition, false] as const,
   };
   const resolvingArgs = {};
   addObjectProperty(
@@ -279,7 +279,7 @@ export function setAndVerifyCollection(
   );
   addAccountMeta(keys, signers, resolvedAccounts.collectionMint, false);
   addAccountMeta(keys, signers, resolvedAccounts.collectionMetadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.editionAccount, false);
+  addAccountMeta(keys, signers, resolvedAccounts.collectionEdition, false);
   addAccountMeta(keys, signers, resolvedAccounts.bubblegumSigner, false);
   addAccountMeta(keys, signers, resolvedAccounts.logWrapper, false);
   addAccountMeta(keys, signers, resolvedAccounts.compressionProgram, false);

--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -37,7 +37,7 @@ import {
 
 // Accounts.
 export type SetAndVerifyCollectionInstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
@@ -160,9 +160,9 @@ export function setAndVerifyCollection(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, false] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, false] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -231,7 +231,7 @@ export function setAndVerifyCollection(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafOwner, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);

--- a/clients/js/src/generated/instructions/setTreeDelegate.ts
+++ b/clients/js/src/generated/instructions/setTreeDelegate.ts
@@ -28,7 +28,7 @@ import { addAccountMeta, addObjectProperty } from '../shared';
 
 // Accounts.
 export type SetTreeDelegateInstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   treeCreator?: Signer;
   newTreeDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
@@ -97,9 +97,9 @@ export function setTreeDelegate(
   };
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, true] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, true] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -128,7 +128,7 @@ export function setTreeDelegate(
         ] as const)
   );
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.treeCreator, false);
   addAccountMeta(keys, signers, resolvedAccounts.newTreeDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);

--- a/clients/js/src/generated/instructions/transfer.ts
+++ b/clients/js/src/generated/instructions/transfer.ts
@@ -31,7 +31,7 @@ import { addAccountMeta, addObjectProperty } from '../shared';
 
 // Accounts.
 export type TransferInstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda | Signer;
   leafDelegate?: PublicKey | Pda | Signer;
   newLeafOwner: PublicKey | Pda;
@@ -119,9 +119,9 @@ export function transfer(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, false] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, false] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -177,7 +177,7 @@ export function transfer(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafOwner, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.newLeafOwner, false);

--- a/clients/js/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js/src/generated/instructions/unverifyCollection.ts
@@ -41,7 +41,7 @@ export type UnverifyCollectionInstructionAccounts = {
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
-  treeCreatorOrDelegate: PublicKey | Pda;
+  treeCreatorOrDelegate?: PublicKey | Pda;
   collectionAuthority: Signer;
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
@@ -124,7 +124,7 @@ export type UnverifyCollectionInstructionArgs =
 
 // Instruction.
 export function unverifyCollection(
-  context: Pick<Context, 'programs' | 'eddsa' | 'payer'>,
+  context: Pick<Context, 'programs' | 'eddsa' | 'identity' | 'payer'>,
   input: UnverifyCollectionInstructionAccounts &
     UnverifyCollectionInstructionArgs
 ): TransactionBuilder {
@@ -142,7 +142,6 @@ export function unverifyCollection(
     leafOwner: [input.leafOwner, false] as const,
     leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
-    treeCreatorOrDelegate: [input.treeCreatorOrDelegate, false] as const,
     collectionAuthority: [input.collectionAuthority, false] as const,
     collectionAuthorityRecordPda: [
       input.collectionAuthorityRecordPda,
@@ -171,6 +170,13 @@ export function unverifyCollection(
     input.payer
       ? ([input.payer, false] as const)
       : ([context.payer, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'treeCreatorOrDelegate',
+    input.treeCreatorOrDelegate
+      ? ([input.treeCreatorOrDelegate, false] as const)
+      : ([context.identity.publicKey, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js/src/generated/instructions/unverifyCollection.ts
@@ -47,7 +47,7 @@ export type UnverifyCollectionInstructionAccounts = {
   collectionMint: PublicKey | Pda;
   collectionMetadata: PublicKey | Pda;
   editionAccount: PublicKey | Pda;
-  bubblegumSigner: PublicKey | Pda;
+  bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
   tokenMetadataProgram?: PublicKey | Pda;
@@ -151,7 +151,6 @@ export function unverifyCollection(
     collectionMint: [input.collectionMint, false] as const,
     collectionMetadata: [input.collectionMetadata, true] as const,
     editionAccount: [input.editionAccount, false] as const,
-    bubblegumSigner: [input.bubblegumSigner, false] as const,
   };
   const resolvingArgs = {};
   addObjectProperty(
@@ -172,6 +171,16 @@ export function unverifyCollection(
     input.payer
       ? ([input.payer, false] as const)
       : ([context.payer, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'bubblegumSigner',
+    input.bubblegumSigner
+      ? ([input.bubblegumSigner, false] as const)
+      : ([
+          publicKey('4ewWZC5gT6TGpm5LZNDs9wVonfUT2q5PP5sc9kVbwMAK'),
+          false,
+        ] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js/src/generated/instructions/unverifyCollection.ts
@@ -41,7 +41,7 @@ export type UnverifyCollectionInstructionAccounts = {
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
-  treeDelegate: PublicKey | Pda;
+  treeCreatorOrDelegate: PublicKey | Pda;
   collectionAuthority: Signer;
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
@@ -142,7 +142,7 @@ export function unverifyCollection(
     leafOwner: [input.leafOwner, false] as const,
     leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
-    treeDelegate: [input.treeDelegate, false] as const,
+    treeCreatorOrDelegate: [input.treeCreatorOrDelegate, false] as const,
     collectionAuthority: [input.collectionAuthority, false] as const,
     collectionAuthorityRecordPda: [
       input.collectionAuthorityRecordPda,
@@ -241,7 +241,7 @@ export function unverifyCollection(
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);
   addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.treeDelegate, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeCreatorOrDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.collectionAuthority, false);
   addAccountMeta(
     keys,

--- a/clients/js/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js/src/generated/instructions/unverifyCollection.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata';
 import {
   AccountMeta,
   Context,
@@ -45,7 +46,7 @@ export type UnverifyCollectionInstructionAccounts = {
   collectionAuthority: Signer;
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
-  collectionMetadata: PublicKey | Pda;
+  collectionMetadata?: PublicKey | Pda;
   editionAccount: PublicKey | Pda;
   bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
@@ -147,7 +148,6 @@ export function unverifyCollection(
       false,
     ] as const,
     collectionMint: [input.collectionMint, false] as const,
-    collectionMetadata: [input.collectionMetadata, true] as const,
     editionAccount: [input.editionAccount, false] as const,
   };
   const resolvingArgs = {};
@@ -183,6 +183,18 @@ export function unverifyCollection(
     input.treeCreatorOrDelegate
       ? ([input.treeCreatorOrDelegate, false] as const)
       : ([context.identity.publicKey, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionMetadata',
+    input.collectionMetadata
+      ? ([input.collectionMetadata, true] as const)
+      : ([
+          findMetadataPda(context, {
+            mint: publicKey(input.collectionMint, false),
+          }),
+          true,
+        ] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js/src/generated/instructions/unverifyCollection.ts
@@ -47,7 +47,7 @@ export type UnverifyCollectionInstructionAccounts = {
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;
-  editionAccount: PublicKey | Pda;
+  collectionEdition: PublicKey | Pda;
   bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
@@ -148,7 +148,7 @@ export function unverifyCollection(
       false,
     ] as const,
     collectionMint: [input.collectionMint, false] as const,
-    editionAccount: [input.editionAccount, false] as const,
+    collectionEdition: [input.collectionEdition, false] as const,
   };
   const resolvingArgs = {};
   addObjectProperty(
@@ -275,7 +275,7 @@ export function unverifyCollection(
   );
   addAccountMeta(keys, signers, resolvedAccounts.collectionMint, false);
   addAccountMeta(keys, signers, resolvedAccounts.collectionMetadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.editionAccount, false);
+  addAccountMeta(keys, signers, resolvedAccounts.collectionEdition, false);
   addAccountMeta(keys, signers, resolvedAccounts.bubblegumSigner, false);
   addAccountMeta(keys, signers, resolvedAccounts.logWrapper, false);
   addAccountMeta(keys, signers, resolvedAccounts.compressionProgram, false);

--- a/clients/js/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js/src/generated/instructions/unverifyCollection.ts
@@ -36,7 +36,7 @@ import {
 
 // Accounts.
 export type UnverifyCollectionInstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
@@ -156,9 +156,9 @@ export function unverifyCollection(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, false] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, false] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -227,7 +227,7 @@ export function unverifyCollection(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafOwner, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);

--- a/clients/js/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js/src/generated/instructions/unverifyCollection.ts
@@ -6,7 +6,10 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata';
+import {
+  findMasterEditionPda,
+  findMetadataPda,
+} from '@metaplex-foundation/mpl-token-metadata';
 import {
   AccountMeta,
   Context,
@@ -47,7 +50,7 @@ export type UnverifyCollectionInstructionAccounts = {
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;
-  collectionEdition: PublicKey | Pda;
+  collectionEdition?: PublicKey | Pda;
   bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
@@ -148,7 +151,6 @@ export function unverifyCollection(
       false,
     ] as const,
     collectionMint: [input.collectionMint, false] as const,
-    collectionEdition: [input.collectionEdition, false] as const,
   };
   const resolvingArgs = {};
   addObjectProperty(
@@ -194,6 +196,18 @@ export function unverifyCollection(
             mint: publicKey(input.collectionMint, false),
           }),
           true,
+        ] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionEdition',
+    input.collectionEdition
+      ? ([input.collectionEdition, false] as const)
+      : ([
+          findMasterEditionPda(context, {
+            mint: publicKey(input.collectionMint, false),
+          }),
+          false,
         ] as const)
   );
   addObjectProperty(

--- a/clients/js/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js/src/generated/instructions/unverifyCollection.ts
@@ -38,7 +38,7 @@ import {
 export type UnverifyCollectionInstructionAccounts = {
   treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
-  leafDelegate: PublicKey | Pda;
+  leafDelegate?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
   treeCreatorOrDelegate?: PublicKey | Pda;
@@ -140,7 +140,6 @@ export function unverifyCollection(
   // Resolved inputs.
   const resolvedAccounts = {
     leafOwner: [input.leafOwner, false] as const,
-    leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
     collectionAuthority: [input.collectionAuthority, false] as const,
     collectionAuthorityRecordPda: [
@@ -163,6 +162,13 @@ export function unverifyCollection(
           }),
           false,
         ] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'leafDelegate',
+    input.leafDelegate
+      ? ([input.leafDelegate, false] as const)
+      : ([input.leafOwner, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js/src/generated/instructions/unverifyCollection.ts
@@ -46,8 +46,8 @@ export type UnverifyCollectionInstructionAccounts = {
   merkleTree: PublicKey | Pda;
   payer?: Signer;
   treeCreatorOrDelegate?: PublicKey | Pda;
-  collectionAuthority: Signer;
-  collectionAuthorityRecordPda: PublicKey | Pda;
+  collectionAuthority?: Signer;
+  collectionAuthorityRecordPda?: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;
   collectionEdition?: PublicKey | Pda;
@@ -145,11 +145,6 @@ export function unverifyCollection(
   const resolvedAccounts = {
     leafOwner: [input.leafOwner, false] as const,
     merkleTree: [input.merkleTree, true] as const,
-    collectionAuthority: [input.collectionAuthority, false] as const,
-    collectionAuthorityRecordPda: [
-      input.collectionAuthorityRecordPda,
-      false,
-    ] as const,
     collectionMint: [input.collectionMint, false] as const,
   };
   const resolvingArgs = {};
@@ -185,6 +180,20 @@ export function unverifyCollection(
     input.treeCreatorOrDelegate
       ? ([input.treeCreatorOrDelegate, false] as const)
       : ([context.identity.publicKey, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionAuthority',
+    input.collectionAuthority
+      ? ([input.collectionAuthority, false] as const)
+      : ([context.identity, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionAuthorityRecordPda',
+    input.collectionAuthorityRecordPda
+      ? ([input.collectionAuthorityRecordPda, false] as const)
+      : ([programId, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/unverifyCreator.ts
+++ b/clients/js/src/generated/instructions/unverifyCreator.ts
@@ -38,7 +38,7 @@ import {
 export type UnverifyCreatorInstructionAccounts = {
   treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
-  leafDelegate: PublicKey | Pda;
+  leafDelegate?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
   creator: Signer;
@@ -131,7 +131,6 @@ export function unverifyCreator(
   // Resolved inputs.
   const resolvedAccounts = {
     leafOwner: [input.leafOwner, false] as const,
-    leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
     creator: [input.creator, false] as const,
   };
@@ -147,6 +146,13 @@ export function unverifyCreator(
           }),
           false,
         ] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'leafDelegate',
+    input.leafDelegate
+      ? ([input.leafDelegate, false] as const)
+      : ([input.leafOwner, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/unverifyCreator.ts
+++ b/clients/js/src/generated/instructions/unverifyCreator.ts
@@ -36,7 +36,7 @@ import {
 
 // Accounts.
 export type UnverifyCreatorInstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
@@ -138,9 +138,9 @@ export function unverifyCreator(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, false] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, false] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -196,7 +196,7 @@ export function unverifyCreator(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafOwner, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);

--- a/clients/js/src/generated/instructions/verifyCollection.ts
+++ b/clients/js/src/generated/instructions/verifyCollection.ts
@@ -47,7 +47,7 @@ export type VerifyCollectionInstructionAccounts = {
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;
-  editionAccount: PublicKey | Pda;
+  collectionEdition: PublicKey | Pda;
   bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
@@ -147,7 +147,7 @@ export function verifyCollection(
       false,
     ] as const,
     collectionMint: [input.collectionMint, false] as const,
-    editionAccount: [input.editionAccount, false] as const,
+    collectionEdition: [input.collectionEdition, false] as const,
   };
   const resolvingArgs = {};
   addObjectProperty(
@@ -274,7 +274,7 @@ export function verifyCollection(
   );
   addAccountMeta(keys, signers, resolvedAccounts.collectionMint, false);
   addAccountMeta(keys, signers, resolvedAccounts.collectionMetadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.editionAccount, false);
+  addAccountMeta(keys, signers, resolvedAccounts.collectionEdition, false);
   addAccountMeta(keys, signers, resolvedAccounts.bubblegumSigner, false);
   addAccountMeta(keys, signers, resolvedAccounts.logWrapper, false);
   addAccountMeta(keys, signers, resolvedAccounts.compressionProgram, false);

--- a/clients/js/src/generated/instructions/verifyCollection.ts
+++ b/clients/js/src/generated/instructions/verifyCollection.ts
@@ -41,7 +41,7 @@ export type VerifyCollectionInstructionAccounts = {
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
-  treeDelegate: PublicKey | Pda;
+  treeCreatorOrDelegate: PublicKey | Pda;
   collectionAuthority: Signer;
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
@@ -141,7 +141,7 @@ export function verifyCollection(
     leafOwner: [input.leafOwner, false] as const,
     leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
-    treeDelegate: [input.treeDelegate, false] as const,
+    treeCreatorOrDelegate: [input.treeCreatorOrDelegate, false] as const,
     collectionAuthority: [input.collectionAuthority, false] as const,
     collectionAuthorityRecordPda: [
       input.collectionAuthorityRecordPda,
@@ -240,7 +240,7 @@ export function verifyCollection(
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);
   addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.treeDelegate, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeCreatorOrDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.collectionAuthority, false);
   addAccountMeta(
     keys,

--- a/clients/js/src/generated/instructions/verifyCollection.ts
+++ b/clients/js/src/generated/instructions/verifyCollection.ts
@@ -36,7 +36,7 @@ import {
 
 // Accounts.
 export type VerifyCollectionInstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
@@ -155,9 +155,9 @@ export function verifyCollection(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, false] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, false] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -226,7 +226,7 @@ export function verifyCollection(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafOwner, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);

--- a/clients/js/src/generated/instructions/verifyCollection.ts
+++ b/clients/js/src/generated/instructions/verifyCollection.ts
@@ -46,8 +46,8 @@ export type VerifyCollectionInstructionAccounts = {
   merkleTree: PublicKey | Pda;
   payer?: Signer;
   treeCreatorOrDelegate?: PublicKey | Pda;
-  collectionAuthority: Signer;
-  collectionAuthorityRecordPda: PublicKey | Pda;
+  collectionAuthority?: Signer;
+  collectionAuthorityRecordPda?: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;
   collectionEdition?: PublicKey | Pda;
@@ -144,11 +144,6 @@ export function verifyCollection(
   const resolvedAccounts = {
     leafOwner: [input.leafOwner, false] as const,
     merkleTree: [input.merkleTree, true] as const,
-    collectionAuthority: [input.collectionAuthority, false] as const,
-    collectionAuthorityRecordPda: [
-      input.collectionAuthorityRecordPda,
-      false,
-    ] as const,
     collectionMint: [input.collectionMint, false] as const,
   };
   const resolvingArgs = {};
@@ -184,6 +179,20 @@ export function verifyCollection(
     input.treeCreatorOrDelegate
       ? ([input.treeCreatorOrDelegate, false] as const)
       : ([context.identity.publicKey, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionAuthority',
+    input.collectionAuthority
+      ? ([input.collectionAuthority, false] as const)
+      : ([context.identity, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionAuthorityRecordPda',
+    input.collectionAuthorityRecordPda
+      ? ([input.collectionAuthorityRecordPda, false] as const)
+      : ([programId, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/verifyCollection.ts
+++ b/clients/js/src/generated/instructions/verifyCollection.ts
@@ -47,7 +47,7 @@ export type VerifyCollectionInstructionAccounts = {
   collectionMint: PublicKey | Pda;
   collectionMetadata: PublicKey | Pda;
   editionAccount: PublicKey | Pda;
-  bubblegumSigner: PublicKey | Pda;
+  bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
   tokenMetadataProgram?: PublicKey | Pda;
@@ -150,7 +150,6 @@ export function verifyCollection(
     collectionMint: [input.collectionMint, false] as const,
     collectionMetadata: [input.collectionMetadata, true] as const,
     editionAccount: [input.editionAccount, false] as const,
-    bubblegumSigner: [input.bubblegumSigner, false] as const,
   };
   const resolvingArgs = {};
   addObjectProperty(
@@ -171,6 +170,16 @@ export function verifyCollection(
     input.payer
       ? ([input.payer, false] as const)
       : ([context.payer, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'bubblegumSigner',
+    input.bubblegumSigner
+      ? ([input.bubblegumSigner, false] as const)
+      : ([
+          publicKey('4ewWZC5gT6TGpm5LZNDs9wVonfUT2q5PP5sc9kVbwMAK'),
+          false,
+        ] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/verifyCollection.ts
+++ b/clients/js/src/generated/instructions/verifyCollection.ts
@@ -41,7 +41,7 @@ export type VerifyCollectionInstructionAccounts = {
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
-  treeCreatorOrDelegate: PublicKey | Pda;
+  treeCreatorOrDelegate?: PublicKey | Pda;
   collectionAuthority: Signer;
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
@@ -124,7 +124,7 @@ export type VerifyCollectionInstructionArgs =
 
 // Instruction.
 export function verifyCollection(
-  context: Pick<Context, 'programs' | 'eddsa' | 'payer'>,
+  context: Pick<Context, 'programs' | 'eddsa' | 'identity' | 'payer'>,
   input: VerifyCollectionInstructionAccounts & VerifyCollectionInstructionArgs
 ): TransactionBuilder {
   const signers: Signer[] = [];
@@ -141,7 +141,6 @@ export function verifyCollection(
     leafOwner: [input.leafOwner, false] as const,
     leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
-    treeCreatorOrDelegate: [input.treeCreatorOrDelegate, false] as const,
     collectionAuthority: [input.collectionAuthority, false] as const,
     collectionAuthorityRecordPda: [
       input.collectionAuthorityRecordPda,
@@ -170,6 +169,13 @@ export function verifyCollection(
     input.payer
       ? ([input.payer, false] as const)
       : ([context.payer, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'treeCreatorOrDelegate',
+    input.treeCreatorOrDelegate
+      ? ([input.treeCreatorOrDelegate, false] as const)
+      : ([context.identity.publicKey, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/verifyCollection.ts
+++ b/clients/js/src/generated/instructions/verifyCollection.ts
@@ -6,7 +6,10 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata';
+import {
+  findMasterEditionPda,
+  findMetadataPda,
+} from '@metaplex-foundation/mpl-token-metadata';
 import {
   AccountMeta,
   Context,
@@ -47,7 +50,7 @@ export type VerifyCollectionInstructionAccounts = {
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;
-  collectionEdition: PublicKey | Pda;
+  collectionEdition?: PublicKey | Pda;
   bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;
@@ -147,7 +150,6 @@ export function verifyCollection(
       false,
     ] as const,
     collectionMint: [input.collectionMint, false] as const,
-    collectionEdition: [input.collectionEdition, false] as const,
   };
   const resolvingArgs = {};
   addObjectProperty(
@@ -193,6 +195,18 @@ export function verifyCollection(
             mint: publicKey(input.collectionMint, false),
           }),
           true,
+        ] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionEdition',
+    input.collectionEdition
+      ? ([input.collectionEdition, false] as const)
+      : ([
+          findMasterEditionPda(context, {
+            mint: publicKey(input.collectionMint, false),
+          }),
+          false,
         ] as const)
   );
   addObjectProperty(

--- a/clients/js/src/generated/instructions/verifyCollection.ts
+++ b/clients/js/src/generated/instructions/verifyCollection.ts
@@ -38,7 +38,7 @@ import {
 export type VerifyCollectionInstructionAccounts = {
   treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
-  leafDelegate: PublicKey | Pda;
+  leafDelegate?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
   treeCreatorOrDelegate?: PublicKey | Pda;
@@ -139,7 +139,6 @@ export function verifyCollection(
   // Resolved inputs.
   const resolvedAccounts = {
     leafOwner: [input.leafOwner, false] as const,
-    leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
     collectionAuthority: [input.collectionAuthority, false] as const,
     collectionAuthorityRecordPda: [
@@ -162,6 +161,13 @@ export function verifyCollection(
           }),
           false,
         ] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'leafDelegate',
+    input.leafDelegate
+      ? ([input.leafDelegate, false] as const)
+      : ([input.leafOwner, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/verifyCollection.ts
+++ b/clients/js/src/generated/instructions/verifyCollection.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata';
 import {
   AccountMeta,
   Context,
@@ -45,7 +46,7 @@ export type VerifyCollectionInstructionAccounts = {
   collectionAuthority: Signer;
   collectionAuthorityRecordPda: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
-  collectionMetadata: PublicKey | Pda;
+  collectionMetadata?: PublicKey | Pda;
   editionAccount: PublicKey | Pda;
   bubblegumSigner?: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
@@ -146,7 +147,6 @@ export function verifyCollection(
       false,
     ] as const,
     collectionMint: [input.collectionMint, false] as const,
-    collectionMetadata: [input.collectionMetadata, true] as const,
     editionAccount: [input.editionAccount, false] as const,
   };
   const resolvingArgs = {};
@@ -182,6 +182,18 @@ export function verifyCollection(
     input.treeCreatorOrDelegate
       ? ([input.treeCreatorOrDelegate, false] as const)
       : ([context.identity.publicKey, false] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'collectionMetadata',
+    input.collectionMetadata
+      ? ([input.collectionMetadata, true] as const)
+      : ([
+          findMetadataPda(context, {
+            mint: publicKey(input.collectionMint, false),
+          }),
+          true,
+        ] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/verifyCreator.ts
+++ b/clients/js/src/generated/instructions/verifyCreator.ts
@@ -38,7 +38,7 @@ import {
 export type VerifyCreatorInstructionAccounts = {
   treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
-  leafDelegate: PublicKey | Pda;
+  leafDelegate?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
   creator: Signer;
@@ -122,7 +122,6 @@ export function verifyCreator(
   // Resolved inputs.
   const resolvedAccounts = {
     leafOwner: [input.leafOwner, false] as const,
-    leafDelegate: [input.leafDelegate, false] as const,
     merkleTree: [input.merkleTree, true] as const,
     creator: [input.creator, false] as const,
   };
@@ -138,6 +137,13 @@ export function verifyCreator(
           }),
           false,
         ] as const)
+  );
+  addObjectProperty(
+    resolvedAccounts,
+    'leafDelegate',
+    input.leafDelegate
+      ? ([input.leafDelegate, false] as const)
+      : ([input.leafOwner, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/src/generated/instructions/verifyCreator.ts
+++ b/clients/js/src/generated/instructions/verifyCreator.ts
@@ -36,7 +36,7 @@ import {
 
 // Accounts.
 export type VerifyCreatorInstructionAccounts = {
-  treeAuthority?: PublicKey | Pda;
+  treeConfig?: PublicKey | Pda;
   leafOwner: PublicKey | Pda;
   leafDelegate: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
@@ -129,9 +129,9 @@ export function verifyCreator(
   const resolvingArgs = {};
   addObjectProperty(
     resolvedAccounts,
-    'treeAuthority',
-    input.treeAuthority
-      ? ([input.treeAuthority, false] as const)
+    'treeConfig',
+    input.treeConfig
+      ? ([input.treeConfig, false] as const)
       : ([
           findTreeConfigPda(context, {
             merkleTree: publicKey(input.merkleTree, false),
@@ -187,7 +187,7 @@ export function verifyCreator(
   );
   const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.treeAuthority, false);
+  addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafOwner, false);
   addAccountMeta(keys, signers, resolvedAccounts.leafDelegate, false);
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
+import { mplTokenMetadata } from '@metaplex-foundation/mpl-token-metadata';
 import {
   Context,
   Pda,
@@ -20,7 +21,9 @@ import {
 } from '../src';
 
 export const createUmi = async (endpoint?: string, airdropAmount?: SolAmount) =>
-  (await baseCreateUmi(endpoint, undefined, airdropAmount)).use(mplBubblegum());
+  (await baseCreateUmi(endpoint, undefined, airdropAmount))
+    .use(mplTokenMetadata())
+    .use(mplBubblegum());
 
 export const createTree = async (
   context: Context,

--- a/clients/js/test/mintToCollectionV1.test.ts
+++ b/clients/js/test/mintToCollectionV1.test.ts
@@ -1,0 +1,79 @@
+import { createNft } from '@metaplex-foundation/mpl-token-metadata';
+import {
+  defaultPublicKey,
+  generateSigner,
+  percentAmount,
+  publicKey,
+  some,
+} from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  MPL_BUBBLEGUM_PROGRAM_ID,
+  MetadataArgsArgs,
+  fetchMerkleTree,
+  hashLeaf,
+  mintToCollectionV1,
+} from '../src';
+import { createTree, createUmi } from './_setup';
+
+test('it can mint an NFT from a collection', async (t) => {
+  // Given an empty Bubblegum tree.
+  const umi = await createUmi();
+  const merkleTree = await createTree(umi);
+  const leafOwner = generateSigner(umi).publicKey;
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.sequenceNumber, 0n);
+  t.is(merkleTreeAccount.tree.activeIndex, 0n);
+  t.is(merkleTreeAccount.tree.bufferSize, 1n);
+  t.is(merkleTreeAccount.tree.rightMostPath.index, 0);
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, defaultPublicKey());
+
+  // And a Collection NFT.
+  const collectionMint = generateSigner(umi);
+  await createNft(umi, {
+    mint: collectionMint,
+    name: 'My Collection',
+    uri: 'https://example.com/my-collection.json',
+    sellerFeeBasisPoints: percentAmount(5.5), // 5.5%
+    isCollection: true,
+  }).sendAndConfirm(umi);
+
+  // When we mint a new NFT from the tree using the following metadata.
+  const metadata: MetadataArgsArgs = {
+    name: 'My NFT',
+    uri: 'https://example.com/my-nft.json',
+    sellerFeeBasisPoints: 550, // 5.5%
+    collection: {
+      key: collectionMint.publicKey,
+      verified: false,
+    },
+    creators: [],
+  };
+  await mintToCollectionV1(umi, {
+    leafOwner,
+    merkleTree,
+    message: metadata,
+    collectionMint: collectionMint.publicKey,
+    collectionAuthority: umi.identity,
+    collectionAuthorityRecordPda: MPL_BUBBLEGUM_PROGRAM_ID,
+  }).sendAndConfirm(umi);
+
+  // Then a new leaf was added to the merkle tree.
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.sequenceNumber, 1n);
+  t.is(merkleTreeAccount.tree.activeIndex, 1n);
+  t.is(merkleTreeAccount.tree.bufferSize, 2n);
+  t.is(merkleTreeAccount.tree.rightMostPath.index, 1);
+
+  // And the hash of the metadata matches the new leaf.
+  const leaf = hashLeaf(umi, {
+    merkleTree,
+    owner: leafOwner,
+    leafIndex: 0,
+    metadata: {
+      ...metadata,
+      collection: some({ key: collectionMint.publicKey, verified: true }),
+    },
+  });
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(leaf));
+});

--- a/clients/js/test/mintToCollectionV1.test.ts
+++ b/clients/js/test/mintToCollectionV1.test.ts
@@ -8,7 +8,6 @@ import {
 } from '@metaplex-foundation/umi';
 import test from 'ava';
 import {
-  MPL_BUBBLEGUM_PROGRAM_ID,
   MetadataArgsArgs,
   fetchMerkleTree,
   hashLeaf,
@@ -54,8 +53,6 @@ test('it can mint an NFT from a collection', async (t) => {
     merkleTree,
     message: metadata,
     collectionMint: collectionMint.publicKey,
-    collectionAuthority: umi.identity,
-    collectionAuthorityRecordPda: MPL_BUBBLEGUM_PROGRAM_ID,
   }).sendAndConfirm(umi);
 
   // Then a new leaf was added to the merkle tree.

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -111,6 +111,15 @@ kinobi.update(
       ignoreIfOptional: true,
       ...k.publicKeyDefault("4ewWZC5gT6TGpm5LZNDs9wVonfUT2q5PP5sc9kVbwMAK"),
     },
+    // TODO: collectionAuthorityRecordPda, when new metadata delegates are supported to avoid breaking changes.
+    {
+      account: "collectionMetadata",
+      ignoreIfOptional: true,
+      ...k.pdaDefault("metadata", {
+        importFrom: "mplTokenMetadata",
+        seeds: { mint: k.accountDefault("collectionMint") },
+      }),
+    },
   ])
 );
 
@@ -219,4 +228,11 @@ kinobi.update(
 // Render JavaScript.
 const jsDir = path.join(clientDir, "js", "src", "generated");
 const prettier = require(path.join(clientDir, "js", ".prettierrc.json"));
-kinobi.accept(new k.RenderJavaScriptVisitor(jsDir, { prettier }));
+kinobi.accept(
+  new k.RenderJavaScriptVisitor(jsDir, {
+    prettier,
+    dependencyMap: {
+      mplTokenMetadata: "@metaplex-foundation/mpl-token-metadata",
+    },
+  })
+);

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -42,6 +42,20 @@ kinobi.update(
   })
 );
 
+// Custom tree updates.
+kinobi.update(
+  new k.TransformNodesVisitor([
+    {
+      // Rename `treeAuthority` instruction account to `treeConfig`.
+      selector: { kind: "instructionAccountNode", name: "treeAuthority" },
+      transformer: (node) => {
+        k.assertInstructionAccountNode(node);
+        return k.instructionAccountNode({ ...node, name: "treeConfig" });
+      },
+    },
+  ])
+);
+
 // Set default account values accross multiple instructions.
 kinobi.update(
   new k.SetInstructionAccountDefaultValuesVisitor([
@@ -67,7 +81,7 @@ kinobi.update(
       ...k.identityDefault(),
     },
     {
-      account: "treeAuthority",
+      account: "treeConfig",
       ignoreIfOptional: true,
       ...k.pdaDefault("treeConfig"),
     },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -53,6 +53,17 @@ kinobi.update(
         return k.instructionAccountNode({ ...node, name: "treeConfig" });
       },
     },
+    {
+      // Rename `treeDelegate` instruction account to `treeCreatorOrDelegate`.
+      selector: { kind: "instructionAccountNode", name: "treeDelegate" },
+      transformer: (node) => {
+        k.assertInstructionAccountNode(node);
+        return k.instructionAccountNode({
+          ...node,
+          name: "treeCreatorOrDelegate",
+        });
+      },
+    },
   ])
 );
 
@@ -103,8 +114,7 @@ kinobi.update(
     mintV1: {
       accounts: {
         leafDelegate: { defaultsTo: k.accountDefault("leafOwner") },
-        treeDelegate: {
-          name: "treeCreatorOrDelegate",
+        treeCreatorOrDelegate: {
           defaultsTo: k.identityDefault(),
         },
       },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -135,7 +135,16 @@ kinobi.update(
         seeds: { mint: k.accountDefault("collectionMint") },
       }),
     },
-    // TODO: collectionAuthorityRecordPda, when new metadata delegates are supported to avoid breaking changes.
+    {
+      account: "collectionAuthorityRecordPda",
+      ignoreIfOptional: true,
+      ...k.programIdDefault(),
+    },
+    {
+      account: "collectionAuthority",
+      ignoreIfOptional: true,
+      ...k.identityDefault(),
+    },
   ])
 );
 

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -97,6 +97,11 @@ kinobi.update(
       ...k.identityDefault(),
     },
     {
+      account: "leafDelegate",
+      ignoreIfOptional: true,
+      ...k.accountDefault("leafOwner"),
+    },
+    {
       account: "treeConfig",
       ignoreIfOptional: true,
       ...k.pdaDefault("treeConfig"),
@@ -116,18 +121,10 @@ kinobi.update(
       name: "createTreeConfig",
       bytesCreatedOnChain: k.bytesFromAccount("treeConfig"),
     },
-    mintV1: {
-      accounts: {
-        leafDelegate: { defaultsTo: k.accountDefault("leafOwner") },
-      },
-    },
     transfer: {
       accounts: {
         leafOwner: { isSigner: "either" },
-        leafDelegate: {
-          isSigner: "either",
-          defaultsTo: k.accountDefault("leafOwner"),
-        },
+        leafDelegate: { isSigner: "either" },
       },
     },
     decompressV1: {

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -121,6 +121,11 @@ kinobi.update(
       name: "createTreeConfig",
       bytesCreatedOnChain: k.bytesFromAccount("treeConfig"),
     },
+    mintToCollectionV1: {
+      args: {
+        metadataArgs: { name: "message" },
+      },
+    },
     transfer: {
       accounts: {
         leafOwner: { isSigner: "either" },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -64,6 +64,14 @@ kinobi.update(
         });
       },
     },
+    {
+      // Rename `editionAccount` instruction account to `collectionEdition`.
+      selector: { kind: "instructionAccountNode", name: "editionAccount" },
+      transformer: (node) => {
+        k.assertInstructionAccountNode(node);
+        return k.instructionAccountNode({ ...node, name: "collectionEdition" });
+      },
+    },
   ])
 );
 

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -119,7 +119,6 @@ kinobi.update(
       ignoreIfOptional: true,
       ...k.publicKeyDefault("4ewWZC5gT6TGpm5LZNDs9wVonfUT2q5PP5sc9kVbwMAK"),
     },
-    // TODO: collectionAuthorityRecordPda, when new metadata delegates are supported to avoid breaking changes.
     {
       account: "collectionMetadata",
       ignoreIfOptional: true,
@@ -128,6 +127,15 @@ kinobi.update(
         seeds: { mint: k.accountDefault("collectionMint") },
       }),
     },
+    {
+      account: "collectionEdition",
+      ignoreIfOptional: true,
+      ...k.pdaDefault("masterEdition", {
+        importFrom: "mplTokenMetadata",
+        seeds: { mint: k.accountDefault("collectionMint") },
+      }),
+    },
+    // TODO: collectionAuthorityRecordPda, when new metadata delegates are supported to avoid breaking changes.
   ])
 );
 

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -85,6 +85,11 @@ kinobi.update(
       ignoreIfOptional: true,
       ...k.pdaDefault("treeConfig"),
     },
+    {
+      account: "bubblegumSigner",
+      ignoreIfOptional: true,
+      ...k.publicKeyDefault("4ewWZC5gT6TGpm5LZNDs9wVonfUT2q5PP5sc9kVbwMAK"),
+    },
   ])
 );
 

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -92,6 +92,11 @@ kinobi.update(
       ...k.identityDefault(),
     },
     {
+      account: "treeCreatorOrDelegate",
+      ignoreIfOptional: true,
+      ...k.identityDefault(),
+    },
+    {
       account: "treeConfig",
       ignoreIfOptional: true,
       ...k.pdaDefault("treeConfig"),
@@ -114,9 +119,6 @@ kinobi.update(
     mintV1: {
       accounts: {
         leafDelegate: { defaultsTo: k.accountDefault("leafOwner") },
-        treeCreatorOrDelegate: {
-          defaultsTo: k.identityDefault(),
-        },
       },
     },
     transfer: {


### PR DESCRIPTION
This PR also renames `treeAuthority` to `treeConfig` on all instructions since they always refer to the `TreeConfig` account and never an "authority" for the tree which causes unnecessary confusion.