### PR TITLE
[Umi] Add collection delegate tests for mintToCollectionV1

### DIFF
--- a/clients/js/test/mintToCollectionV1.test.ts
+++ b/clients/js/test/mintToCollectionV1.test.ts
@@ -1,4 +1,12 @@
-import { createNft } from '@metaplex-foundation/mpl-token-metadata';
+import {
+  MetadataDelegateRole,
+  TokenStandard,
+  approveCollectionAuthority,
+  createNft,
+  delegateCollectionV1,
+  findCollectionAuthorityRecordPda,
+  findMetadataDelegateRecordPda,
+} from '@metaplex-foundation/mpl-token-metadata';
 import {
   defaultPublicKey,
   generateSigner,
@@ -61,6 +69,143 @@ test('it can mint an NFT from a collection', async (t) => {
   t.is(merkleTreeAccount.tree.activeIndex, 1n);
   t.is(merkleTreeAccount.tree.bufferSize, 2n);
   t.is(merkleTreeAccount.tree.rightMostPath.index, 1);
+
+  // And the hash of the metadata matches the new leaf.
+  const leaf = hashLeaf(umi, {
+    merkleTree,
+    owner: leafOwner,
+    leafIndex: 0,
+    metadata: {
+      ...metadata,
+      collection: some({ key: collectionMint.publicKey, verified: true }),
+    },
+  });
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(leaf));
+});
+
+test.skip('it can mint an NFT from a collection using a collection delegate', async (t) => {
+  // Given an empty Bubblegum tree.
+  const umi = await createUmi();
+  const merkleTree = await createTree(umi);
+  const leafOwner = generateSigner(umi).publicKey;
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.activeIndex, 0n);
+
+  // And a delegated Collection NFT.
+  const collectionDelegate = generateSigner(umi);
+  const collectionMint = generateSigner(umi);
+  await createNft(umi, {
+    mint: collectionMint,
+    name: 'My Collection',
+    uri: 'https://example.com/my-collection.json',
+    sellerFeeBasisPoints: percentAmount(5.5), // 5.5%
+    isCollection: true,
+  })
+    .add(
+      delegateCollectionV1(umi, {
+        mint: collectionMint.publicKey,
+        delegate: collectionDelegate.publicKey,
+        tokenStandard: TokenStandard.NonFungible,
+      })
+    )
+    .sendAndConfirm(umi);
+
+  // When we mint a new NFT from the tree using the collection delegate.
+  const metadata: MetadataArgsArgs = {
+    name: 'My NFT',
+    uri: 'https://example.com/my-nft.json',
+    sellerFeeBasisPoints: 550, // 5.5%
+    collection: {
+      key: collectionMint.publicKey,
+      verified: false,
+    },
+    creators: [],
+  };
+  await mintToCollectionV1(umi, {
+    leafOwner,
+    merkleTree,
+    message: metadata,
+    collectionMint: collectionMint.publicKey,
+    collectionAuthority: collectionDelegate,
+    collectionAuthorityRecordPda: findMetadataDelegateRecordPda(umi, {
+      mint: collectionMint.publicKey,
+      delegateRole: MetadataDelegateRole.Collection,
+      delegate: collectionDelegate.publicKey,
+      updateAuthority: umi.identity.publicKey,
+    }),
+  }).sendAndConfirm(umi);
+
+  // Then a new leaf was added to the merkle tree.
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.activeIndex, 1n);
+
+  // And the hash of the metadata matches the new leaf.
+  const leaf = hashLeaf(umi, {
+    merkleTree,
+    owner: leafOwner,
+    leafIndex: 0,
+    metadata: {
+      ...metadata,
+      collection: some({ key: collectionMint.publicKey, verified: true }),
+    },
+  });
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(leaf));
+});
+
+test('it can mint an NFT from a collection using a legacy collection delegate', async (t) => {
+  // Given an empty Bubblegum tree.
+  const umi = await createUmi();
+  const merkleTree = await createTree(umi);
+  const leafOwner = generateSigner(umi).publicKey;
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.activeIndex, 0n);
+
+  // And a delegated Collection NFT.
+  const collectionMint = generateSigner(umi);
+  const collectionDelegate = generateSigner(umi);
+  const collectionAuthorityRecordPda = findCollectionAuthorityRecordPda(umi, {
+    mint: collectionMint.publicKey,
+    collectionAuthority: collectionDelegate.publicKey,
+  });
+  await createNft(umi, {
+    mint: collectionMint,
+    name: 'My Collection',
+    uri: 'https://example.com/my-collection.json',
+    sellerFeeBasisPoints: percentAmount(5.5), // 5.5%
+    isCollection: true,
+  })
+    .add(
+      approveCollectionAuthority(umi, {
+        mint: collectionMint.publicKey,
+        newCollectionAuthority: collectionDelegate.publicKey,
+        collectionAuthorityRecord: collectionAuthorityRecordPda,
+      })
+    )
+    .sendAndConfirm(umi);
+
+  // When we mint a new NFT from the tree using the collection delegate.
+  const metadata: MetadataArgsArgs = {
+    name: 'My NFT',
+    uri: 'https://example.com/my-nft.json',
+    sellerFeeBasisPoints: 550, // 5.5%
+    collection: {
+      key: collectionMint.publicKey,
+      verified: false,
+    },
+    creators: [],
+  };
+  await mintToCollectionV1(umi, {
+    leafOwner,
+    merkleTree,
+    message: metadata,
+    collectionMint: collectionMint.publicKey,
+    collectionAuthority: collectionDelegate,
+    collectionAuthorityRecordPda,
+  }).sendAndConfirm(umi);
+
+  // Then a new leaf was added to the merkle tree.
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.activeIndex, 1n);
 
   // And the hash of the metadata matches the new leaf.
   const leaf = hashLeaf(umi, {

--- a/clients/js/test/mintToCollectionV1.test.ts
+++ b/clients/js/test/mintToCollectionV1.test.ts
@@ -83,7 +83,7 @@ test('it can mint an NFT from a collection', async (t) => {
   t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(leaf));
 });
 
-test.skip('it can mint an NFT from a collection using a collection delegate', async (t) => {
+test('it can mint an NFT from a collection using a collection delegate', async (t) => {
   // Given an empty Bubblegum tree.
   const umi = await createUmi();
   const merkleTree = await createTree(umi);


### PR DESCRIPTION
Waiting for https://github.com/metaplex-foundation/metaplex-program-library/pull/1139 to be deployed to mainnet so the new collection authority test can pass.