### PR TITLE
Compare on-chain and local binaries

### DIFF
--- a/configs/program-scripts/dump.sh
+++ b/configs/program-scripts/dump.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# output colours
+RED() { echo $'\e[1;31m'$1$'\e[0m'; }
+GRN() { echo $'\e[1;32m'$1$'\e[0m'; }
+
 CURRENT_DIR=$(pwd)
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 # go to parent folder
@@ -23,11 +27,33 @@ if [ ! -d ${OUTPUT} ]; then
     mkdir ${OUTPUT}
 fi
 
+# only prints this if we have external programs
+if [ ${#EXTERNAL_ID[@]} -gt 0 ]; then
+    echo "Dumping external programs to: '${OUTPUT}'"
+fi
+
 # dump external programs binaries if needed
 for i in ${!EXTERNAL_ID[@]}; do
     if [ ! -f "${OUTPUT}/${EXTERNAL_SO[$i]}" ]; then
         solana program dump -u $RPC ${EXTERNAL_ID[$i]} ${OUTPUT}/${EXTERNAL_SO[$i]}
+    else
+        solana program dump -u $RPC ${EXTERNAL_ID[$i]} ${OUTPUT}/onchain-${EXTERNAL_SO[$i]} > /dev/null
+        ON_CHAIN=`sha256sum -b ${OUTPUT}/onchain-${EXTERNAL_SO[$i]} | cut -d ' ' -f 1`
+        LOCAL=`sha256sum -b ${OUTPUT}/${EXTERNAL_SO[$i]} | cut -d ' ' -f 1`
+
+        if [ "$ON_CHAIN" != "$LOCAL" ]; then
+            echo $(RED "[ WARNING ] on-chain and local binaries are different for '${EXTERNAL_SO[$i]}'")
+        else
+            echo "$(GRN "[ SKIPPED ]") on-chain and local binaries are the same for '${EXTERNAL_SO[$i]}'"
+        fi
+
+        rm ${OUTPUT}/onchain-${EXTERNAL_SO[$i]}
     fi
 done
+
+# only prints this if we have external programs
+if [ ${#EXTERNAL_ID[@]} -gt 0 ]; then
+    echo ""
+fi
 
 cd ${CURRENT_DIR}


### PR DESCRIPTION
This PR adds a binary comparison when copying on-chain programs. The `dump.sh` script now displays the result of the comparison:

![image](https://github.com/metaplex-foundation/mpl-bubblegum/assets/729235/0c1eb26b-bc89-4e8e-82dc-9cb1b570c9ef)

This is useful to detect whether the binaries being used are the same from the deployment environment or local.