### PR TITLE
[Umi] delegate and burn instructions

### DIFF
--- a/clients/js/src/generated/instructions/burn.ts
+++ b/clients/js/src/generated/instructions/burn.ts
@@ -32,8 +32,8 @@ import { addAccountMeta, addObjectProperty } from '../shared';
 // Accounts.
 export type BurnInstructionAccounts = {
   treeConfig?: PublicKey | Pda;
-  leafOwner: PublicKey | Pda;
-  leafDelegate?: PublicKey | Pda;
+  leafOwner: PublicKey | Pda | Signer;
+  leafDelegate?: PublicKey | Pda | Signer;
   merkleTree: PublicKey | Pda;
   logWrapper?: PublicKey | Pda;
   compressionProgram?: PublicKey | Pda;

--- a/clients/js/test/burn.test.ts
+++ b/clients/js/test/burn.test.ts
@@ -1,0 +1,82 @@
+import { defaultPublicKey, generateSigner } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  burn,
+  delegate,
+  fetchMerkleTree,
+  getCurrentRoot,
+  hashMetadataCreators,
+  hashMetadataData,
+} from '../src';
+import { createTree, createUmi, mint } from './_setup';
+
+test('it can burn a compressed NFT', async (t) => {
+  // Given a tree with a minted NFT.
+  const umi = await createUmi();
+  const merkleTree = await createTree(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  const leafOwner = generateSigner(umi);
+  const { metadata, leafIndex } = await mint(umi, {
+    merkleTree,
+    leafOwner: leafOwner.publicKey,
+  });
+
+  // When the owner of the NFT burns it.
+  await burn(umi, {
+    leafOwner,
+    merkleTree,
+    root: getCurrentRoot(merkleTreeAccount.tree),
+    dataHash: hashMetadataData(metadata),
+    creatorHash: hashMetadataCreators(metadata.creators),
+    nonce: leafIndex,
+    index: leafIndex,
+  })
+    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
+    .sendAndConfirm(umi);
+
+  // Then the leaf was deleted in the merkle tree.
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, defaultPublicKey());
+});
+
+test('it can burn a compressed NFT as a delegated authority', async (t) => {
+  // Given a tree with a delegated compressed NFT.
+  const umi = await createUmi();
+  const merkleTree = await createTree(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  const leafOwner = generateSigner(umi);
+  const delegateAuthority = generateSigner(umi);
+  const { metadata, leafIndex } = await mint(umi, {
+    merkleTree,
+    leafOwner: leafOwner.publicKey,
+  });
+  await delegate(umi, {
+    leafOwner,
+    previousLeafDelegate: leafOwner.publicKey,
+    newLeafDelegate: delegateAuthority.publicKey,
+    merkleTree,
+    root: getCurrentRoot(merkleTreeAccount.tree),
+    dataHash: hashMetadataData(metadata),
+    creatorHash: hashMetadataCreators(metadata.creators),
+    nonce: leafIndex,
+    index: leafIndex,
+  }).sendAndConfirm(umi);
+
+  // When the delegated authority burns the NFT.
+  await burn(umi, {
+    leafOwner: leafOwner.publicKey,
+    leafDelegate: delegateAuthority, // <- The delegated authority signs the transaction.
+    merkleTree,
+    root: getCurrentRoot(merkleTreeAccount.tree),
+    dataHash: hashMetadataData(metadata),
+    creatorHash: hashMetadataCreators(metadata.creators),
+    nonce: leafIndex,
+    index: leafIndex,
+  })
+    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
+    .sendAndConfirm(umi);
+
+  // Then the leaf was deleted in the merkle tree.
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, defaultPublicKey());
+});

--- a/clients/js/test/delegate.test.ts
+++ b/clients/js/test/delegate.test.ts
@@ -1,0 +1,50 @@
+import { generateSigner, publicKey } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  delegate,
+  fetchMerkleTree,
+  getCurrentRoot,
+  hashLeaf,
+  hashMetadataCreators,
+  hashMetadataData,
+} from '../src';
+import { createTree, createUmi, mint } from './_setup';
+
+test('it can delegate a compressed NFT', async (t) => {
+  // Given a tree with a minted NFT.
+  const umi = await createUmi();
+  const merkleTree = await createTree(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  const leafOwner = generateSigner(umi);
+  const { metadata, leafIndex } = await mint(umi, {
+    merkleTree,
+    leafOwner: leafOwner.publicKey,
+  });
+
+  // When the owner of the NFT delegates it to another account.
+  const newDelegate = generateSigner(umi).publicKey;
+  await delegate(umi, {
+    leafOwner,
+    previousLeafDelegate: leafOwner.publicKey,
+    newLeafDelegate: newDelegate,
+    merkleTree,
+    root: getCurrentRoot(merkleTreeAccount.tree),
+    dataHash: hashMetadataData(metadata),
+    creatorHash: hashMetadataCreators(metadata.creators),
+    nonce: leafIndex,
+    index: leafIndex,
+  })
+    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
+    .sendAndConfirm(umi);
+
+  // Then the leaf was updated in the merkle tree.
+  const updatedLeaf = hashLeaf(umi, {
+    merkleTree,
+    owner: leafOwner.publicKey,
+    delegate: newDelegate,
+    leafIndex,
+    metadata,
+  });
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(updatedLeaf));
+});

--- a/clients/js/test/setTreeDelegate.test.ts
+++ b/clients/js/test/setTreeDelegate.test.ts
@@ -1,0 +1,29 @@
+import { generateSigner } from '@metaplex-foundation/umi';
+import test from 'ava';
+import { TreeConfig, fetchTreeConfigFromSeeds, setTreeDelegate } from '../src';
+import { createTree, createUmi } from './_setup';
+
+test('it can set a delegate on a Bubblegum tree', async (t) => {
+  // Given a Bubblegum tree.
+  const umi = await createUmi();
+  const merkleTree = await createTree(umi);
+  let treeConfig = await fetchTreeConfigFromSeeds(umi, { merkleTree });
+  t.like(treeConfig, <TreeConfig>{
+    treeCreator: umi.identity.publicKey,
+    treeDelegate: umi.identity.publicKey,
+  });
+
+  // When we set a new delegate on the tree.
+  const treeDelegate = generateSigner(umi).publicKey;
+  await setTreeDelegate(umi, {
+    merkleTree,
+    newTreeDelegate: treeDelegate,
+  }).sendAndConfirm(umi);
+
+  // Then the tree config account was updated accordingly.
+  treeConfig = await fetchTreeConfigFromSeeds(umi, { merkleTree });
+  t.like(treeConfig, <TreeConfig>{
+    treeCreator: umi.identity.publicKey,
+    treeDelegate,
+  });
+});

--- a/clients/js/test/transfer.test.ts
+++ b/clients/js/test/transfer.test.ts
@@ -1,6 +1,7 @@
 import { generateSigner, publicKey } from '@metaplex-foundation/umi';
 import test from 'ava';
 import {
+  delegate,
   fetchMerkleTree,
   getCurrentRoot,
   hashLeaf,
@@ -40,6 +41,57 @@ test('it can transfer a compressed NFT', async (t) => {
   const updatedLeaf = hashLeaf(umi, {
     merkleTree,
     owner: leafOwnerB.publicKey,
+    leafIndex,
+    metadata,
+  });
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(updatedLeaf));
+});
+
+test('it can transfer a compressed NFT as a delegated authority', async (t) => {
+  // Given a tree with a delegated compressed NFT owned by leafOwnerA.
+  const umi = await createUmi();
+  const merkleTree = await createTree(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  const leafOwnerA = generateSigner(umi);
+  const delegateAuthority = generateSigner(umi);
+  const { metadata, leafIndex } = await mint(umi, {
+    merkleTree,
+    leafOwner: leafOwnerA.publicKey,
+  });
+  await delegate(umi, {
+    leafOwner: leafOwnerA,
+    previousLeafDelegate: leafOwnerA.publicKey,
+    newLeafDelegate: delegateAuthority.publicKey,
+    merkleTree,
+    root: getCurrentRoot(merkleTreeAccount.tree),
+    dataHash: hashMetadataData(metadata),
+    creatorHash: hashMetadataCreators(metadata.creators),
+    nonce: leafIndex,
+    index: leafIndex,
+  }).sendAndConfirm(umi);
+
+  // When the delegated authority transfers the NFT to leafOwnerB.
+  const leafOwnerB = generateSigner(umi);
+  await transfer(umi, {
+    leafDelegate: delegateAuthority, // <- The delegated authority signs the transaction.
+    leafOwner: leafOwnerA.publicKey,
+    newLeafOwner: leafOwnerB.publicKey,
+    merkleTree,
+    root: getCurrentRoot(merkleTreeAccount.tree),
+    dataHash: hashMetadataData(metadata),
+    creatorHash: hashMetadataCreators(metadata.creators),
+    nonce: leafIndex,
+    index: leafIndex,
+  })
+    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
+    .sendAndConfirm(umi);
+
+  // Then the leaf was updated in the merkle tree.
+  const updatedLeaf = hashLeaf(umi, {
+    merkleTree,
+    owner: leafOwnerB.publicKey,
+    delegate: leafOwnerB.publicKey, // <- The delegated authority is removed.
     leafIndex,
     metadata,
   });

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -193,6 +193,12 @@ kinobi.update(
         leafDelegate: { isSigner: "either" },
       },
     },
+    burn: {
+      accounts: {
+        leafOwner: { isSigner: "either" },
+        leafDelegate: { isSigner: "either" },
+      },
+    },
     redeem: {
       accounts: {
         voucher: {


### PR DESCRIPTION
This PR configures and tests the following instructions using the Umi library:
- `delegate`: the owner of a leaf can delegate it. It also ensures the delegated authority can transfer the leaf and, as a result, clears the delegate.
- `setTreeDelegate`: the owner of a tree can delegate it.
- `burn`: the owner of a leaf can burn it. Here as well, it ensures the delegated authority can burn.