### PR TITLE
Add creator_hash accessor to leaf schema model

### DIFF
--- a/programs/bubblegum/program/src/state/leaf_schema.rs
+++ b/programs/bubblegum/program/src/state/leaf_schema.rs
@@ -109,6 +109,12 @@ impl LeafSchema {
         }
     }
 
+    pub fn creator_hash(&self) -> [u8; 32] {
+        match self {
+            LeafSchema::V1 { creator_hash, .. } => *creator_hash,
+        }
+    }
+
     pub fn to_event(&self) -> LeafSchemaEvent {
         LeafSchemaEvent::new(self.version(), self.clone(), self.to_node())
     }


### PR DESCRIPTION
# Overview

Add accessor to get creator_hash from the leaf schema model.

## Why?

We need to access the creator_hash in the Blockbuster repository when parsing Bubblegum transactions. The creator_hash is required to fix a bug for cNFT indexing (invalid data/creator hashes after out-of-order indexing).

# Testing
N/A