### PR TITLE
Rename message arg to metadata

### DIFF
--- a/clients/js/src/generated/instructions/decompressV1.ts
+++ b/clients/js/src/generated/instructions/decompressV1.ts
@@ -43,7 +43,7 @@ export type DecompressV1InstructionAccounts = {
   tokenAccount?: PublicKey | Pda;
   mint: PublicKey | Pda;
   mintAuthority?: PublicKey | Pda;
-  metadata?: PublicKey | Pda;
+  metadataAccount?: PublicKey | Pda;
   masterEdition?: PublicKey | Pda;
   systemProgram?: PublicKey | Pda;
   sysvarRent?: PublicKey | Pda;
@@ -56,10 +56,10 @@ export type DecompressV1InstructionAccounts = {
 // Data.
 export type DecompressV1InstructionData = {
   discriminator: Array<number>;
-  message: MetadataArgs;
+  metadata: MetadataArgs;
 };
 
-export type DecompressV1InstructionDataArgs = { message: MetadataArgsArgs };
+export type DecompressV1InstructionDataArgs = { metadata: MetadataArgsArgs };
 
 /** @deprecated Use `getDecompressV1InstructionDataSerializer()` without any argument instead. */
 export function getDecompressV1InstructionDataSerializer(
@@ -80,7 +80,7 @@ export function getDecompressV1InstructionDataSerializer(
     struct<DecompressV1InstructionData>(
       [
         ['discriminator', array(u8(), { size: 8 })],
-        ['message', getMetadataArgsSerializer()],
+        ['metadata', getMetadataArgsSerializer()],
       ],
       { description: 'DecompressV1InstructionData' }
     ),
@@ -140,9 +140,9 @@ export function decompressV1(
   );
   addObjectProperty(
     resolvedAccounts,
-    'metadata',
-    input.metadata
-      ? ([input.metadata, true] as const)
+    'metadataAccount',
+    input.metadataAccount
+      ? ([input.metadataAccount, true] as const)
       : ([
           findMetadataPda(context, { mint: publicKey(input.mint, false) }),
           true,
@@ -240,7 +240,7 @@ export function decompressV1(
   addAccountMeta(keys, signers, resolvedAccounts.tokenAccount, false);
   addAccountMeta(keys, signers, resolvedAccounts.mint, false);
   addAccountMeta(keys, signers, resolvedAccounts.mintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
+  addAccountMeta(keys, signers, resolvedAccounts.metadataAccount, false);
   addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
   addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
   addAccountMeta(keys, signers, resolvedAccounts.sysvarRent, false);

--- a/clients/js/src/generated/instructions/mintToCollectionV1.ts
+++ b/clients/js/src/generated/instructions/mintToCollectionV1.ts
@@ -58,11 +58,11 @@ export type MintToCollectionV1InstructionAccounts = {
 // Data.
 export type MintToCollectionV1InstructionData = {
   discriminator: Array<number>;
-  message: MetadataArgs;
+  metadata: MetadataArgs;
 };
 
 export type MintToCollectionV1InstructionDataArgs = {
-  message: MetadataArgsArgs;
+  metadata: MetadataArgsArgs;
 };
 
 /** @deprecated Use `getMintToCollectionV1InstructionDataSerializer()` without any argument instead. */
@@ -90,7 +90,7 @@ export function getMintToCollectionV1InstructionDataSerializer(
     struct<MintToCollectionV1InstructionData>(
       [
         ['discriminator', array(u8(), { size: 8 })],
-        ['message', getMetadataArgsSerializer()],
+        ['metadata', getMetadataArgsSerializer()],
       ],
       { description: 'MintToCollectionV1InstructionData' }
     ),

--- a/clients/js/test/decompressV1.test.ts
+++ b/clients/js/test/decompressV1.test.ts
@@ -53,7 +53,7 @@ test('it can decompress a redeemed compressed NFT', async (t) => {
   await decompressV1(umi, {
     leafOwner,
     voucher,
-    message: metadata,
+    metadata,
     mint: decompressedMint,
   }).sendAndConfirm(umi);
 

--- a/clients/js/test/mintToCollectionV1.test.ts
+++ b/clients/js/test/mintToCollectionV1.test.ts
@@ -59,7 +59,7 @@ test('it can mint an NFT from a collection', async (t) => {
   await mintToCollectionV1(umi, {
     leafOwner,
     merkleTree,
-    message: metadata,
+    metadata,
     collectionMint: collectionMint.publicKey,
   }).sendAndConfirm(umi);
 
@@ -124,7 +124,7 @@ test('it can mint an NFT from a collection using a collection delegate', async (
   await mintToCollectionV1(umi, {
     leafOwner,
     merkleTree,
-    message: metadata,
+    metadata,
     collectionMint: collectionMint.publicKey,
     collectionAuthority: collectionDelegate,
     collectionAuthorityRecordPda: findMetadataDelegateRecordPda(umi, {
@@ -197,7 +197,7 @@ test('it can mint an NFT from a collection using a legacy collection delegate', 
   await mintToCollectionV1(umi, {
     leafOwner,
     merkleTree,
-    message: metadata,
+    metadata,
     collectionMint: collectionMint.publicKey,
     collectionAuthority: collectionDelegate,
     collectionAuthorityRecordPda,

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -167,12 +167,12 @@ kinobi.update(
 const hashDefaults = {
   dataHash: {
     defaultsTo: k.resolverDefault("resolveDataHash", [
-      k.dependsOnArg("message"),
+      k.dependsOnArg("metadata"),
     ]),
   },
   creatorHash: {
     defaultsTo: k.resolverDefault("resolveCreatorHash", [
-      k.dependsOnArg("message"),
+      k.dependsOnArg("metadata"),
     ]),
   },
 };
@@ -184,7 +184,7 @@ kinobi.update(
     },
     mintToCollectionV1: {
       args: {
-        metadataArgs: { name: "message" },
+        metadataArgs: { name: "metadata" },
       },
     },
     transfer: {
@@ -214,6 +214,7 @@ kinobi.update(
     decompressV1: {
       accounts: {
         metadata: {
+          name: "metadataAccount",
           defaultsTo: k.pdaDefault("metadata", {
             importFrom: "mplTokenMetadata",
             seeds: { mint: k.accountDefault("mint") },
@@ -240,9 +241,6 @@ kinobi.update(
             seeds: { mint: k.accountDefault("mint") },
           }),
         },
-      },
-      args: {
-        metadata: { name: "message" },
       },
     },
     setAndVerifyCollection: {


### PR DESCRIPTION
Initially, I decided to rename the `metadata` arg to `message` because it was conflicting with the `metadata` account for the `decompress` instruction.

However, whilst writing the docs, I realised it's better to rename the `metadata` account to `metadataAccount` instead to keep the name `metadata` for the arg.

```ts
await mintV1(umi, {
  leafOwner,
  merkleTree,
  metadata: { // <- Calling this "message" here is confusing.
    name: 'My Compressed NFT',
    uri: 'https://example.com/my-cnft.json',
    // ...
  },
}).sendAndConfirm(umi)
```