### PR TITLE
[Umi] Use proof argument as remaining accounts

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@metaplex-foundation/mpl-token-metadata": "3.0.0-alpha.24",
     "@metaplex-foundation/mpl-toolbox": "^0.8.0",
-    "@noble/hashes": "^1.3.1"
+    "@noble/hashes": "^1.3.1",
+    "merkletreejs": "^0.3.9"
   },
   "peerDependencies": {
     "@metaplex-foundation/umi": "^0.8.2"

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -10,6 +10,9 @@ dependencies:
   '@noble/hashes':
     specifier: ^1.3.1
     version: 1.3.1
+  merkletreejs:
+    specifier: ^0.3.9
+    version: 0.3.9
 
 devDependencies:
   '@ava/typescript':
@@ -2018,6 +2021,12 @@ packages:
       '@types/estree': 1.0.0
     dev: true
 
+  /@types/bn.js@5.1.1:
+    resolution: {integrity: sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==}
+    dependencies:
+      '@types/node': 18.11.17
+    dev: false
+
   /@types/cacheable-request@6.0.3:
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
     dependencies:
@@ -2118,7 +2127,12 @@ packages:
 
   /@types/node@18.11.17:
     resolution: {integrity: sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==}
-    dev: true
+
+  /@types/pbkdf2@3.1.0:
+    resolution: {integrity: sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==}
+    dependencies:
+      '@types/node': 18.11.17
+    dev: false
 
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
@@ -2141,6 +2155,12 @@ packages:
   /@types/scheduler@0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
     dev: true
+
+  /@types/secp256k1@4.0.3:
+    resolution: {integrity: sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==}
+    dependencies:
+      '@types/node': 18.11.17
+    dev: false
 
   /@types/semver@7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
@@ -2838,7 +2858,6 @@ packages:
     resolution: {integrity: sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==}
     dependencies:
       safe-buffer: 5.2.1
-    dev: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2855,6 +2874,10 @@ packages:
     dependencies:
       bindings: 1.5.0
     dev: true
+
+  /bignumber.js@9.1.1:
+    resolution: {integrity: sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==}
+    dev: false
 
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -2875,13 +2898,24 @@ packages:
       readable-stream: 3.6.0
     dev: true
 
+  /blakejs@1.2.1:
+    resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
+    dev: false
+
   /blueimp-md5@2.19.0:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
     dev: true
 
+  /bn.js@4.11.6:
+    resolution: {integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==}
+    dev: false
+
+  /bn.js@4.12.0:
+    resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
+    dev: false
+
   /bn.js@5.2.1:
     resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
-    dev: true
 
   /body-parser@1.20.1:
     resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
@@ -2931,6 +2965,21 @@ packages:
       fill-range: 7.0.1
     dev: true
 
+  /brorand@1.1.0:
+    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
+    dev: false
+
+  /browserify-aes@1.2.0:
+    resolution: {integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==}
+    dependencies:
+      buffer-xor: 1.0.3
+      cipher-base: 1.0.4
+      create-hash: 1.2.0
+      evp_bytestokey: 1.0.3
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: false
+
   /browserify-zlib@0.1.4:
     resolution: {integrity: sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==}
     dependencies:
@@ -2952,11 +3001,26 @@ packages:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
     dependencies:
       base-x: 3.0.9
-    dev: true
+
+  /bs58check@2.1.2:
+    resolution: {integrity: sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==}
+    dependencies:
+      bs58: 4.0.1
+      create-hash: 1.2.0
+      safe-buffer: 5.2.1
+    dev: false
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
+
+  /buffer-reverse@1.0.1:
+    resolution: {integrity: sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==}
+    dev: false
+
+  /buffer-xor@1.0.3:
+    resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
+    dev: false
 
   /buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -3142,6 +3206,13 @@ packages:
   /ci-parallel-vars@1.0.1:
     resolution: {integrity: sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==}
     dev: true
+
+  /cipher-base@1.0.4:
+    resolution: {integrity: sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==}
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: false
 
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -3330,6 +3401,27 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
 
+  /create-hash@1.2.0:
+    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
+    dependencies:
+      cipher-base: 1.0.4
+      inherits: 2.0.4
+      md5.js: 1.3.5
+      ripemd160: 2.0.2
+      sha.js: 2.4.11
+    dev: false
+
+  /create-hmac@1.1.7:
+    resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
+    dependencies:
+      cipher-base: 1.0.4
+      create-hash: 1.2.0
+      inherits: 2.0.4
+      ripemd160: 2.0.2
+      safe-buffer: 5.2.1
+      sha.js: 2.4.11
+    dev: false
+
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
     dev: true
@@ -3342,6 +3434,10 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
     dev: true
+
+  /crypto-js@3.3.0:
+    resolution: {integrity: sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==}
+    dev: false
 
   /css-what@5.1.0:
     resolution: {integrity: sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==}
@@ -3605,6 +3701,18 @@ packages:
   /electron-to-chromium@1.4.299:
     resolution: {integrity: sha512-lQ7ijJghH6pCGbfWXr6EY+KYCMaRSjgsY925r1p/TlpSfVM1VjHTcn1gAc15VM4uwti283X6QtjPTXdpoSGiZQ==}
     dev: true
+
+  /elliptic@6.5.4:
+    resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
+    dependencies:
+      bn.js: 4.12.0
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+    dev: false
 
   /emittery@1.0.1:
     resolution: {integrity: sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ==}
@@ -4279,6 +4387,51 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
+  /ethereum-bloom-filters@1.0.10:
+    resolution: {integrity: sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==}
+    dependencies:
+      js-sha3: 0.8.0
+    dev: false
+
+  /ethereum-cryptography@0.1.3:
+    resolution: {integrity: sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==}
+    dependencies:
+      '@types/pbkdf2': 3.1.0
+      '@types/secp256k1': 4.0.3
+      blakejs: 1.2.1
+      browserify-aes: 1.2.0
+      bs58check: 2.1.2
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      hash.js: 1.1.7
+      keccak: 3.0.3
+      pbkdf2: 3.1.2
+      randombytes: 2.1.0
+      safe-buffer: 5.2.1
+      scrypt-js: 3.0.1
+      secp256k1: 4.0.3
+      setimmediate: 1.0.5
+    dev: false
+
+  /ethereumjs-util@7.1.5:
+    resolution: {integrity: sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@types/bn.js': 5.1.1
+      bn.js: 5.2.1
+      create-hash: 1.2.0
+      ethereum-cryptography: 0.1.3
+      rlp: 2.2.7
+    dev: false
+
+  /ethjs-unit@0.1.6:
+    resolution: {integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+    dependencies:
+      bn.js: 4.11.6
+      number-to-bn: 1.7.0
+    dev: false
+
   /eval@0.1.6:
     resolution: {integrity: sha512-o0XUw+5OGkXw4pJZzQoXUk+H87DHuC+7ZE//oSrRGtatTmr12oTnLfg6QOq9DyTt0c/p4TwzgmkKrBzWTSizyQ==}
     engines: {node: '>= 0.8'}
@@ -4289,6 +4442,13 @@ packages:
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
     dev: true
+
+  /evp_bytestokey@1.0.3:
+    resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
+    dependencies:
+      md5.js: 1.3.5
+      safe-buffer: 5.2.1
+    dev: false
 
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -4835,6 +4995,22 @@ packages:
       function-bind: 1.1.1
     dev: true
 
+  /hash-base@3.1.0:
+    resolution: {integrity: sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==}
+    engines: {node: '>=4'}
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.0
+      safe-buffer: 5.2.1
+    dev: false
+
+  /hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+    dev: false
+
   /hast-util-to-estree@2.3.2:
     resolution: {integrity: sha512-YYDwATNdnvZi3Qi84iatPIl1lWpXba1MeNrNbDfJfVzEBZL8uUmtR7mt7bxKBC8kuAuvb0bkojXYZzsNHyHCLg==}
     dependencies:
@@ -4860,6 +5036,14 @@ packages:
   /hast-util-whitespace@2.0.1:
     resolution: {integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==}
     dev: true
+
+  /hmac-drbg@1.0.1:
+    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+    dev: false
 
   /http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
@@ -4987,7 +5171,6 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /inline-style-parser@0.1.1:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
@@ -5134,6 +5317,11 @@ packages:
     resolution: {integrity: sha512-rcfALRIb1YewtnksfRIHGcIY93QnK8BIQ/2c9yDYcG/Y6+vRoJuTWBmmSEbyLLYtXm7q35pHOHbZFQBaLrhlWQ==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /is-hex-prefixed@1.0.0:
+    resolution: {integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+    dev: false
 
   /is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
@@ -5306,6 +5494,10 @@ packages:
     resolution: {integrity: sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==}
     dev: true
 
+  /js-sha3@0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
+    dev: false
+
   /js-string-escape@1.0.1:
     resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
     engines: {node: '>= 0.8'}
@@ -5413,6 +5605,16 @@ packages:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
     dev: true
+
+  /keccak@3.0.3:
+    resolution: {integrity: sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==}
+    engines: {node: '>=10.0.0'}
+    requiresBuild: true
+    dependencies:
+      node-addon-api: 2.0.2
+      node-gyp-build: 4.6.0
+      readable-stream: 3.6.0
+    dev: false
 
   /keyv@4.5.2:
     resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
@@ -5578,6 +5780,14 @@ packages:
       blueimp-md5: 2.19.0
     dev: true
 
+  /md5.js@1.3.5:
+    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
+    dependencies:
+      hash-base: 3.1.0
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: false
+
   /mdast-util-definitions@5.1.2:
     resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
     dependencies:
@@ -5735,6 +5945,17 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
     dev: true
+
+  /merkletreejs@0.3.9:
+    resolution: {integrity: sha512-NjlATjJr4NEn9s8v/VEHhgwRWaE1eA/Une07d9SEqKzULJi1Wsh0Y3svwJdP2bYLMmgSBHzOrNydMWM1NN9VeQ==}
+    engines: {node: '>= 7.6.0'}
+    dependencies:
+      bignumber.js: 9.1.1
+      buffer-reverse: 1.0.1
+      crypto-js: 3.3.0
+      treeify: 1.1.0
+      web3-utils: 1.10.0
+    dev: false
 
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -6054,6 +6275,14 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+    dev: false
+
+  /minimalistic-crypto-utils@1.0.1:
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
+    dev: false
+
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -6181,6 +6410,10 @@ packages:
     dev: true
     optional: true
 
+  /node-addon-api@2.0.2:
+    resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
+    dev: false
+
   /node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -6196,7 +6429,6 @@ packages:
   /node-gyp-build@4.6.0:
     resolution: {integrity: sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==}
     hasBin: true
-    dev: true
 
   /node-releases@2.0.10:
     resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
@@ -6240,6 +6472,14 @@ packages:
       gauge: 3.0.2
       set-blocking: 2.0.0
     dev: true
+
+  /number-to-bn@1.7.0:
+    resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+    dependencies:
+      bn.js: 4.11.6
+      strip-hex-prefix: 1.0.0
+    dev: false
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -6529,6 +6769,17 @@ packages:
     resolution: {integrity: sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==}
     dev: true
 
+  /pbkdf2@3.1.2:
+    resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
+    engines: {node: '>=0.12'}
+    dependencies:
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      ripemd160: 2.0.2
+      safe-buffer: 5.2.1
+      sha.js: 2.4.11
+    dev: false
+
   /peek-stream@1.1.3:
     resolution: {integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==}
     dependencies:
@@ -6800,6 +7051,12 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -6843,7 +7100,6 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    dev: true
 
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -7024,6 +7280,20 @@ packages:
       glob: 7.2.3
     dev: true
 
+  /ripemd160@2.0.2:
+    resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
+    dependencies:
+      hash-base: 3.1.0
+      inherits: 2.0.4
+    dev: false
+
+  /rlp@2.2.7:
+    resolution: {integrity: sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==}
+    hasBin: true
+    dependencies:
+      bn.js: 5.2.1
+    dev: false
+
   /rollup-plugin-inject@3.0.2:
     resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
@@ -7087,7 +7357,6 @@ packages:
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: true
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -7100,6 +7369,20 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
+
+  /scrypt-js@3.0.1:
+    resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
+    dev: false
+
+  /secp256k1@4.0.3:
+    resolution: {integrity: sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==}
+    engines: {node: '>=10.0.0'}
+    requiresBuild: true
+    dependencies:
+      elliptic: 6.5.4
+      node-addon-api: 2.0.2
+      node-gyp-build: 4.6.0
+    dev: false
 
   /semver@6.1.1:
     resolution: {integrity: sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==}
@@ -7167,9 +7450,21 @@ packages:
     resolution: {integrity: sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==}
     dev: true
 
+  /setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+    dev: false
+
   /setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
     dev: true
+
+  /sha.js@2.4.11:
+    resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
+    hasBin: true
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+    dev: false
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -7364,7 +7659,6 @@ packages:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
     dependencies:
       safe-buffer: 5.2.1
-    dev: true
 
   /stringify-entities@4.0.3:
     resolution: {integrity: sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==}
@@ -7396,6 +7690,13 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
     dev: true
+
+  /strip-hex-prefix@1.0.0:
+    resolution: {integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==}
+    engines: {node: '>=6.5.0', npm: '>=3'}
+    dependencies:
+      is-hex-prefixed: 1.0.0
+    dev: false
 
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -7540,6 +7841,11 @@ packages:
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: true
+
+  /treeify@1.1.0:
+    resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
+    engines: {node: '>=0.6'}
+    dev: false
 
   /trough@2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
@@ -7856,9 +8162,12 @@ packages:
       node-gyp-build: 4.6.0
     dev: true
 
+  /utf8@3.0.0:
+    resolution: {integrity: sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==}
+    dev: false
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: true
 
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -7966,6 +8275,19 @@ packages:
   /web-vitals@0.2.4:
     resolution: {integrity: sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==}
     dev: true
+
+  /web3-utils@1.10.0:
+    resolution: {integrity: sha512-kSaCM0uMcZTNUSmn5vMEhlo02RObGNRRCkdX0V9UTAU0+lrvn0HSaudyCo6CQzuXUsnuY2ERJGCGPfeWmv19Rg==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      bn.js: 5.2.1
+      ethereum-bloom-filters: 1.0.10
+      ethereumjs-util: 7.1.5
+      ethjs-unit: 0.1.6
+      number-to-bn: 1.7.0
+      randombytes: 2.1.0
+      utf8: 3.0.0
+    dev: false
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}

--- a/clients/js/src/generated/instructions/burn.ts
+++ b/clients/js/src/generated/instructions/burn.ts
@@ -27,7 +27,7 @@ import {
   u8,
 } from '@metaplex-foundation/umi/serializers';
 import { findTreeConfigPda } from '../accounts';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import { PickPartial, addAccountMeta, addObjectProperty } from '../shared';
 
 // Accounts.
 export type BurnInstructionAccounts = {
@@ -88,8 +88,14 @@ export function getBurnInstructionDataSerializer(
   ) as Serializer<BurnInstructionDataArgs, BurnInstructionData>;
 }
 
+// Extra Args.
+export type BurnInstructionExtraArgs = { proof: Array<PublicKey> };
+
 // Args.
-export type BurnInstructionArgs = BurnInstructionDataArgs;
+export type BurnInstructionArgs = PickPartial<
+  BurnInstructionDataArgs & BurnInstructionExtraArgs,
+  'proof'
+>;
 
 // Instruction.
 export function burn(
@@ -169,6 +175,7 @@ export function burn(
           false,
         ] as const)
   );
+  addObjectProperty(resolvingArgs, 'proof', input.proof ?? []);
   const resolvedArgs = { ...input, ...resolvingArgs };
 
   addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);

--- a/clients/js/src/generated/instructions/burn.ts
+++ b/clients/js/src/generated/instructions/burn.ts
@@ -186,6 +186,14 @@ export function burn(
   addAccountMeta(keys, signers, resolvedAccounts.compressionProgram, false);
   addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
 
+  // Remaining Accounts.
+  const remainingAccounts = resolvedArgs.proof.map(
+    (address) => [address, false] as const
+  );
+  remainingAccounts.forEach((remainingAccount) =>
+    addAccountMeta(keys, signers, remainingAccount, false)
+  );
+
   // Data.
   const data = getBurnInstructionDataSerializer().serialize(resolvedArgs);
 

--- a/clients/js/src/generated/instructions/mintToCollectionV1.ts
+++ b/clients/js/src/generated/instructions/mintToCollectionV1.ts
@@ -44,6 +44,11 @@ export type MintToCollectionV1InstructionAccounts = {
   payer?: Signer;
   treeCreatorOrDelegate?: Signer;
   collectionAuthority?: Signer;
+  /**
+   * If there is no collecton authority record PDA then
+   * this must be the Bubblegum program address.
+   */
+
   collectionAuthorityRecordPda?: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;

--- a/clients/js/src/generated/instructions/redeem.ts
+++ b/clients/js/src/generated/instructions/redeem.ts
@@ -201,6 +201,14 @@ export function redeem(
   addAccountMeta(keys, signers, resolvedAccounts.compressionProgram, false);
   addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
 
+  // Remaining Accounts.
+  const remainingAccounts = resolvedArgs.proof.map(
+    (address) => [address, false] as const
+  );
+  remainingAccounts.forEach((remainingAccount) =>
+    addAccountMeta(keys, signers, remainingAccount, false)
+  );
+
   // Data.
   const data = getRedeemInstructionDataSerializer().serialize(resolvedArgs);
 

--- a/clients/js/src/generated/instructions/redeem.ts
+++ b/clients/js/src/generated/instructions/redeem.ts
@@ -27,7 +27,7 @@ import {
   u8,
 } from '@metaplex-foundation/umi/serializers';
 import { findTreeConfigPda, findVoucherPda } from '../accounts';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import { PickPartial, addAccountMeta, addObjectProperty } from '../shared';
 
 // Accounts.
 export type RedeemInstructionAccounts = {
@@ -89,8 +89,14 @@ export function getRedeemInstructionDataSerializer(
   ) as Serializer<RedeemInstructionDataArgs, RedeemInstructionData>;
 }
 
+// Extra Args.
+export type RedeemInstructionExtraArgs = { proof: Array<PublicKey> };
+
 // Args.
-export type RedeemInstructionArgs = RedeemInstructionDataArgs;
+export type RedeemInstructionArgs = PickPartial<
+  RedeemInstructionDataArgs & RedeemInstructionExtraArgs,
+  'proof'
+>;
 
 // Instruction.
 export function redeem(
@@ -183,6 +189,7 @@ export function redeem(
           false,
         ] as const)
   );
+  addObjectProperty(resolvingArgs, 'proof', input.proof ?? []);
   const resolvedArgs = { ...input, ...resolvingArgs };
 
   addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);

--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -137,10 +137,16 @@ export function getSetAndVerifyCollectionInstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type SetAndVerifyCollectionInstructionExtraArgs = {
+  proof: Array<PublicKey>;
+};
+
 // Args.
 export type SetAndVerifyCollectionInstructionArgs = PickPartial<
-  SetAndVerifyCollectionInstructionDataArgs,
-  'dataHash' | 'creatorHash' | 'collection'
+  SetAndVerifyCollectionInstructionDataArgs &
+    SetAndVerifyCollectionInstructionExtraArgs,
+  'dataHash' | 'creatorHash' | 'collection' | 'proof'
 >;
 
 // Instruction.
@@ -327,6 +333,7 @@ export function setAndVerifyCollection(
     'collection',
     input.collection ?? publicKey(input.collectionMint, false)
   );
+  addObjectProperty(resolvingArgs, 'proof', input.proof ?? []);
   const resolvedArgs = { ...input, ...resolvingArgs };
 
   addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);

--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -47,8 +47,18 @@ export type SetAndVerifyCollectionInstructionAccounts = {
   leafDelegate?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
+  /**
+   * the case of `set_and_verify_collection` where
+   * we are actually changing the NFT metadata.
+   */
+
   treeCreatorOrDelegate?: PublicKey | Pda;
   collectionAuthority?: Signer;
+  /**
+   * If there is no collecton authority record PDA then
+   * this must be the Bubblegum program address.
+   */
+
   collectionAuthorityRecordPda?: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;

--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -358,6 +358,14 @@ export function setAndVerifyCollection(
   addAccountMeta(keys, signers, resolvedAccounts.tokenMetadataProgram, false);
   addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
 
+  // Remaining Accounts.
+  const remainingAccounts = resolvedArgs.proof.map(
+    (address) => [address, false] as const
+  );
+  remainingAccounts.forEach((remainingAccount) =>
+    addAccountMeta(keys, signers, remainingAccount, false)
+  );
+
   // Data.
   const data =
     getSetAndVerifyCollectionInstructionDataSerializer().serialize(

--- a/clients/js/src/generated/instructions/transfer.ts
+++ b/clients/js/src/generated/instructions/transfer.ts
@@ -27,7 +27,7 @@ import {
   u8,
 } from '@metaplex-foundation/umi/serializers';
 import { findTreeConfigPda } from '../accounts';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import { PickPartial, addAccountMeta, addObjectProperty } from '../shared';
 
 // Accounts.
 export type TransferInstructionAccounts = {
@@ -93,8 +93,14 @@ export function getTransferInstructionDataSerializer(
   ) as Serializer<TransferInstructionDataArgs, TransferInstructionData>;
 }
 
+// Extra Args.
+export type TransferInstructionExtraArgs = { proof: Array<PublicKey> };
+
 // Args.
-export type TransferInstructionArgs = TransferInstructionDataArgs;
+export type TransferInstructionArgs = PickPartial<
+  TransferInstructionDataArgs & TransferInstructionExtraArgs,
+  'proof'
+>;
 
 // Instruction.
 export function transfer(
@@ -175,6 +181,7 @@ export function transfer(
           false,
         ] as const)
   );
+  addObjectProperty(resolvingArgs, 'proof', input.proof ?? []);
   const resolvedArgs = { ...input, ...resolvingArgs };
 
   addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);

--- a/clients/js/src/generated/instructions/transfer.ts
+++ b/clients/js/src/generated/instructions/transfer.ts
@@ -193,6 +193,14 @@ export function transfer(
   addAccountMeta(keys, signers, resolvedAccounts.compressionProgram, false);
   addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
 
+  // Remaining Accounts.
+  const remainingAccounts = resolvedArgs.proof.map(
+    (address) => [address, false] as const
+  );
+  remainingAccounts.forEach((remainingAccount) =>
+    addAccountMeta(keys, signers, remainingAccount, false)
+  );
+
   // Data.
   const data = getTransferInstructionDataSerializer().serialize(resolvedArgs);
 

--- a/clients/js/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js/src/generated/instructions/unverifyCollection.ts
@@ -133,10 +133,16 @@ export function getUnverifyCollectionInstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type UnverifyCollectionInstructionExtraArgs = {
+  proof: Array<PublicKey>;
+};
+
 // Args.
 export type UnverifyCollectionInstructionArgs = PickPartial<
-  UnverifyCollectionInstructionDataArgs,
-  'dataHash' | 'creatorHash'
+  UnverifyCollectionInstructionDataArgs &
+    UnverifyCollectionInstructionExtraArgs,
+  'dataHash' | 'creatorHash' | 'proof'
 >;
 
 // Instruction.
@@ -318,6 +324,7 @@ export function unverifyCollection(
         false
       )
   );
+  addObjectProperty(resolvingArgs, 'proof', input.proof ?? []);
   const resolvedArgs = { ...input, ...resolvingArgs };
 
   addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);

--- a/clients/js/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js/src/generated/instructions/unverifyCollection.ts
@@ -46,8 +46,18 @@ export type UnverifyCollectionInstructionAccounts = {
   leafDelegate?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
+  /**
+   * the case of `set_and_verify_collection` where
+   * we are actually changing the NFT metadata.
+   */
+
   treeCreatorOrDelegate?: PublicKey | Pda;
   collectionAuthority?: Signer;
+  /**
+   * If there is no collecton authority record PDA then
+   * this must be the Bubblegum program address.
+   */
+
   collectionAuthorityRecordPda?: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;

--- a/clients/js/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js/src/generated/instructions/unverifyCollection.ts
@@ -349,6 +349,14 @@ export function unverifyCollection(
   addAccountMeta(keys, signers, resolvedAccounts.tokenMetadataProgram, false);
   addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
 
+  // Remaining Accounts.
+  const remainingAccounts = resolvedArgs.proof.map(
+    (address) => [address, false] as const
+  );
+  remainingAccounts.forEach((remainingAccount) =>
+    addAccountMeta(keys, signers, remainingAccount, false)
+  );
+
   // Data.
   const data =
     getUnverifyCollectionInstructionDataSerializer().serialize(resolvedArgs);

--- a/clients/js/src/generated/instructions/unverifyCreator.ts
+++ b/clients/js/src/generated/instructions/unverifyCreator.ts
@@ -112,10 +112,13 @@ export function getUnverifyCreatorInstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type UnverifyCreatorInstructionExtraArgs = { proof: Array<PublicKey> };
+
 // Args.
 export type UnverifyCreatorInstructionArgs = PickPartial<
-  UnverifyCreatorInstructionDataArgs,
-  'dataHash' | 'creatorHash'
+  UnverifyCreatorInstructionDataArgs & UnverifyCreatorInstructionExtraArgs,
+  'dataHash' | 'creatorHash' | 'proof'
 >;
 
 // Instruction.
@@ -228,6 +231,7 @@ export function unverifyCreator(
         false
       )
   );
+  addObjectProperty(resolvingArgs, 'proof', input.proof ?? []);
   const resolvedArgs = { ...input, ...resolvingArgs };
 
   addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);

--- a/clients/js/src/generated/instructions/unverifyCreator.ts
+++ b/clients/js/src/generated/instructions/unverifyCreator.ts
@@ -244,6 +244,14 @@ export function unverifyCreator(
   addAccountMeta(keys, signers, resolvedAccounts.compressionProgram, false);
   addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
 
+  // Remaining Accounts.
+  const remainingAccounts = resolvedArgs.proof.map(
+    (address) => [address, false] as const
+  );
+  remainingAccounts.forEach((remainingAccount) =>
+    addAccountMeta(keys, signers, remainingAccount, false)
+  );
+
   // Data.
   const data =
     getUnverifyCreatorInstructionDataSerializer().serialize(resolvedArgs);

--- a/clients/js/src/generated/instructions/verifyCollection.ts
+++ b/clients/js/src/generated/instructions/verifyCollection.ts
@@ -133,10 +133,13 @@ export function getVerifyCollectionInstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type VerifyCollectionInstructionExtraArgs = { proof: Array<PublicKey> };
+
 // Args.
 export type VerifyCollectionInstructionArgs = PickPartial<
-  VerifyCollectionInstructionDataArgs,
-  'dataHash' | 'creatorHash'
+  VerifyCollectionInstructionDataArgs & VerifyCollectionInstructionExtraArgs,
+  'dataHash' | 'creatorHash' | 'proof'
 >;
 
 // Instruction.
@@ -317,6 +320,7 @@ export function verifyCollection(
         false
       )
   );
+  addObjectProperty(resolvingArgs, 'proof', input.proof ?? []);
   const resolvedArgs = { ...input, ...resolvingArgs };
 
   addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);

--- a/clients/js/src/generated/instructions/verifyCollection.ts
+++ b/clients/js/src/generated/instructions/verifyCollection.ts
@@ -46,8 +46,18 @@ export type VerifyCollectionInstructionAccounts = {
   leafDelegate?: PublicKey | Pda;
   merkleTree: PublicKey | Pda;
   payer?: Signer;
+  /**
+   * the case of `set_and_verify_collection` where
+   * we are actually changing the NFT metadata.
+   */
+
   treeCreatorOrDelegate?: PublicKey | Pda;
   collectionAuthority?: Signer;
+  /**
+   * If there is no collecton authority record PDA then
+   * this must be the Bubblegum program address.
+   */
+
   collectionAuthorityRecordPda?: PublicKey | Pda;
   collectionMint: PublicKey | Pda;
   collectionMetadata?: PublicKey | Pda;

--- a/clients/js/src/generated/instructions/verifyCollection.ts
+++ b/clients/js/src/generated/instructions/verifyCollection.ts
@@ -345,6 +345,14 @@ export function verifyCollection(
   addAccountMeta(keys, signers, resolvedAccounts.tokenMetadataProgram, false);
   addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
 
+  // Remaining Accounts.
+  const remainingAccounts = resolvedArgs.proof.map(
+    (address) => [address, false] as const
+  );
+  remainingAccounts.forEach((remainingAccount) =>
+    addAccountMeta(keys, signers, remainingAccount, false)
+  );
+
   // Data.
   const data =
     getVerifyCollectionInstructionDataSerializer().serialize(resolvedArgs);

--- a/clients/js/src/generated/instructions/verifyCreator.ts
+++ b/clients/js/src/generated/instructions/verifyCreator.ts
@@ -235,6 +235,14 @@ export function verifyCreator(
   addAccountMeta(keys, signers, resolvedAccounts.compressionProgram, false);
   addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
 
+  // Remaining Accounts.
+  const remainingAccounts = resolvedArgs.proof.map(
+    (address) => [address, false] as const
+  );
+  remainingAccounts.forEach((remainingAccount) =>
+    addAccountMeta(keys, signers, remainingAccount, false)
+  );
+
   // Data.
   const data =
     getVerifyCreatorInstructionDataSerializer().serialize(resolvedArgs);

--- a/clients/js/src/generated/instructions/verifyCreator.ts
+++ b/clients/js/src/generated/instructions/verifyCreator.ts
@@ -103,10 +103,13 @@ export function getVerifyCreatorInstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type VerifyCreatorInstructionExtraArgs = { proof: Array<PublicKey> };
+
 // Args.
 export type VerifyCreatorInstructionArgs = PickPartial<
-  VerifyCreatorInstructionDataArgs,
-  'dataHash' | 'creatorHash'
+  VerifyCreatorInstructionDataArgs & VerifyCreatorInstructionExtraArgs,
+  'dataHash' | 'creatorHash' | 'proof'
 >;
 
 // Instruction.
@@ -219,6 +222,7 @@ export function verifyCreator(
         false
       )
   );
+  addObjectProperty(resolvingArgs, 'proof', input.proof ?? []);
   const resolvedArgs = { ...input, ...resolvingArgs };
 
   addAccountMeta(keys, signers, resolvedAccounts.treeConfig, false);

--- a/clients/js/src/generated/instructions/verifyLeaf.ts
+++ b/clients/js/src/generated/instructions/verifyLeaf.ts
@@ -24,7 +24,7 @@ import {
   u32,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta } from '../shared';
+import { PickPartial, addAccountMeta, addObjectProperty } from '../shared';
 
 // Accounts.
 export type VerifyLeafInstructionAccounts = {
@@ -77,8 +77,14 @@ export function getVerifyLeafInstructionDataSerializer(
   ) as Serializer<VerifyLeafInstructionDataArgs, VerifyLeafInstructionData>;
 }
 
+// Extra Args.
+export type VerifyLeafInstructionExtraArgs = { proof: Array<PublicKey> };
+
 // Args.
-export type VerifyLeafInstructionArgs = VerifyLeafInstructionDataArgs;
+export type VerifyLeafInstructionArgs = PickPartial<
+  VerifyLeafInstructionDataArgs & VerifyLeafInstructionExtraArgs,
+  'proof'
+>;
 
 // Instruction.
 export function verifyLeaf(
@@ -99,6 +105,7 @@ export function verifyLeaf(
     merkleTree: [input.merkleTree, false] as const,
   };
   const resolvingArgs = {};
+  addObjectProperty(resolvingArgs, 'proof', input.proof ?? []);
   const resolvedArgs = { ...input, ...resolvingArgs };
 
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);

--- a/clients/js/src/generated/instructions/verifyLeaf.ts
+++ b/clients/js/src/generated/instructions/verifyLeaf.ts
@@ -110,6 +110,14 @@ export function verifyLeaf(
 
   addAccountMeta(keys, signers, resolvedAccounts.merkleTree, false);
 
+  // Remaining Accounts.
+  const remainingAccounts = resolvedArgs.proof.map(
+    (address) => [address, false] as const
+  );
+  remainingAccounts.forEach((remainingAccount) =>
+    addAccountMeta(keys, signers, remainingAccount, false)
+  );
+
   // Data.
   const data = getVerifyLeafInstructionDataSerializer().serialize(resolvedArgs);
 

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -4,6 +4,7 @@ export * from './generated';
 export * from './hash';
 export * from './hooked';
 export * from './leafAssetId';
+export * from './merkle';
 export * from './plugin';
 export * from './readApiDecorator';
 export * from './readApiTypes';

--- a/clients/js/src/merkle.ts
+++ b/clients/js/src/merkle.ts
@@ -1,0 +1,61 @@
+import { PublicKey, publicKey, publicKeyBytes } from '@metaplex-foundation/umi';
+import { keccak_256 } from '@noble/hashes/sha3';
+import { MerkleTree } from 'merkletreejs';
+
+/**
+ * Creates a Merkle Tree from the provided data.
+ */
+const getMerkleTree = (leaves: PublicKey[], maxDepth: number): MerkleTree =>
+  new MerkleTree(
+    [
+      ...leaves.map((leaf) => publicKeyBytes(leaf)),
+      ...Array(2 ** maxDepth - leaves.length)
+        .fill(0)
+        .map(() => new Uint8Array(32).fill(0)),
+    ],
+    keccak_256,
+    {
+      sortPairs: true,
+    }
+  );
+
+/**
+ * Creates a Merkle Root from the provided data.
+ *
+ * This root provides a short identifier for the
+ * provided data that is unique and deterministic.
+ * This means, we can use this root to verify that
+ * a given data is part of the original data set.
+ */
+export const getMerkleRoot = (
+  leaves: PublicKey[],
+  maxDepth: number
+): PublicKey => publicKey(getMerkleTree(leaves, maxDepth).getRoot());
+
+/**
+ * Creates a Merkle Proof for a given data item.
+ *
+ * This proof can be used to verify that the given
+ * data item is part of the original data set.
+ */
+export const getMerkleProof = (
+  leaves: PublicKey[],
+  maxDepth: number,
+  leaf: PublicKey,
+  index?: number
+): PublicKey[] =>
+  getMerkleTree(leaves, maxDepth)
+    .getProof(Buffer.from(publicKeyBytes(leaf)), index)
+    .map((proofItem) => publicKey(proofItem.data));
+
+/**
+ * Creates a Merkle Proof for a data item at a given index.
+ *
+ * This proof can be used to verify that the data item at
+ * the given index is part of the original data set.
+ */
+export const getMerkleProofAtIndex = (
+  leaves: PublicKey[],
+  maxDepth: number,
+  index: number
+): PublicKey[] => getMerkleProof(leaves, maxDepth, leaves[index], index);

--- a/clients/js/src/merkle.ts
+++ b/clients/js/src/merkle.ts
@@ -13,10 +13,7 @@ const getMerkleTree = (leaves: PublicKey[], maxDepth: number): MerkleTree =>
         .fill(0)
         .map(() => new Uint8Array(32).fill(0)),
     ],
-    keccak_256,
-    {
-      sortPairs: true,
-    }
+    keccak_256
   );
 
 /**

--- a/clients/js/test/burn.test.ts
+++ b/clients/js/test/burn.test.ts
@@ -30,9 +30,8 @@ test('it can burn a compressed NFT', async (t) => {
     creatorHash: hashMetadataCreators(metadata.creators),
     nonce: leafIndex,
     index: leafIndex,
-  })
-    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
-    .sendAndConfirm(umi);
+    proof: [],
+  }).sendAndConfirm(umi);
 
   // Then the leaf was deleted in the merkle tree.
   merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
@@ -72,9 +71,8 @@ test('it can burn a compressed NFT as a delegated authority', async (t) => {
     creatorHash: hashMetadataCreators(metadata.creators),
     nonce: leafIndex,
     index: leafIndex,
-  })
-    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
-    .sendAndConfirm(umi);
+    proof: [],
+  }).sendAndConfirm(umi);
 
   // Then the leaf was deleted in the merkle tree.
   merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);

--- a/clients/js/test/delegate.test.ts
+++ b/clients/js/test/delegate.test.ts
@@ -33,9 +33,8 @@ test('it can delegate a compressed NFT', async (t) => {
     creatorHash: hashMetadataCreators(metadata.creators),
     nonce: leafIndex,
     index: leafIndex,
-  })
-    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
-    .sendAndConfirm(umi);
+    proof: [],
+  }).sendAndConfirm(umi);
 
   // Then the leaf was updated in the merkle tree.
   const updatedLeaf = hashLeaf(umi, {

--- a/clients/js/test/redeem.test.ts
+++ b/clients/js/test/redeem.test.ts
@@ -36,9 +36,8 @@ test('it can redeem a compressed NFT', async (t) => {
     creatorHash,
     nonce: leafIndex,
     index: leafIndex,
-  })
-    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
-    .sendAndConfirm(umi);
+    proof: [],
+  }).sendAndConfirm(umi);
 
   // Then the leaf was removed from the merkle tree.
   merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);

--- a/clients/js/test/setAndVerifyCollection.test.ts
+++ b/clients/js/test/setAndVerifyCollection.test.ts
@@ -43,9 +43,8 @@ test('it can set and verify the collection of a minted compressed NFT', async (t
     nonce: leafIndex,
     index: leafIndex,
     metadata,
-  })
-    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
-    .sendAndConfirm(umi);
+    proof: [],
+  }).sendAndConfirm(umi);
 
   // Then the leaf was updated in the merkle tree.
   const updatedLeaf = hashLeaf(umi, {

--- a/clients/js/test/transfer.test.ts
+++ b/clients/js/test/transfer.test.ts
@@ -107,27 +107,26 @@ test.only('it can transfer a compressed NFT using a proof', async (t) => {
   });
   let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const preMints = [
-    await mint(umi, { merkleTree, leafOwner: generateSigner(umi).publicKey }),
-    await mint(umi, { merkleTree, leafOwner: generateSigner(umi).publicKey }),
-    await mint(umi, { merkleTree, leafOwner: generateSigner(umi).publicKey }),
-    await mint(umi, { merkleTree, leafOwner: generateSigner(umi).publicKey }),
-    await mint(umi, { merkleTree, leafOwner: generateSigner(umi).publicKey }),
-    await mint(umi, { merkleTree, leafOwner: generateSigner(umi).publicKey }),
-    await mint(umi, { merkleTree, leafOwner: generateSigner(umi).publicKey }),
-    await mint(umi, { merkleTree, leafOwner: generateSigner(umi).publicKey }),
+    await mint(umi, { merkleTree, leafIndex: 0 }),
+    await mint(umi, { merkleTree, leafIndex: 1 }),
+    await mint(umi, { merkleTree, leafIndex: 2 }),
+    await mint(umi, { merkleTree, leafIndex: 3 }),
+    await mint(umi, { merkleTree, leafIndex: 4 }),
+    await mint(umi, { merkleTree, leafIndex: 5 }),
+    await mint(umi, { merkleTree, leafIndex: 6 }),
+    await mint(umi, { merkleTree, leafIndex: 7 }),
   ];
 
   // And a 9th minted NFT owned by leafOwnerA.
   const leafOwnerA = generateSigner(umi);
-  const { metadata, leafIndex, leaf } = await mint(umi, {
+  const { metadata, leaf, leafIndex } = await mint(umi, {
     merkleTree,
     leafOwner: leafOwnerA.publicKey,
+    leafIndex: 8,
   });
 
   // And a proof for the 9th minted NFT.
-  const allLeaves = [...preMints.map((m) => m.leaf), leaf];
-  const proof = getMerkleProof(allLeaves, 5, leaf);
-  console.log({ leafIndex, proof, allLeaves });
+  const proof = getMerkleProof([...preMints.map((m) => m.leaf), leaf], 5, leaf);
 
   // When leafOwnerA transfers the NFT to leafOwnerB.
   const leafOwnerB = generateSigner(umi);

--- a/clients/js/test/transfer.test.ts
+++ b/clients/js/test/transfer.test.ts
@@ -33,9 +33,8 @@ test('it can transfer a compressed NFT', async (t) => {
     creatorHash: hashMetadataCreators(metadata.creators),
     nonce: leafIndex,
     index: leafIndex,
-  })
-    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
-    .sendAndConfirm(umi);
+    proof: [],
+  }).sendAndConfirm(umi);
 
   // Then the leaf was updated in the merkle tree.
   const updatedLeaf = hashLeaf(umi, {
@@ -83,9 +82,8 @@ test('it can transfer a compressed NFT as a delegated authority', async (t) => {
     creatorHash: hashMetadataCreators(metadata.creators),
     nonce: leafIndex,
     index: leafIndex,
-  })
-    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
-    .sendAndConfirm(umi);
+    proof: [],
+  }).sendAndConfirm(umi);
 
   // Then the leaf was updated in the merkle tree.
   const updatedLeaf = hashLeaf(umi, {

--- a/clients/js/test/unverifyCollection.test.ts
+++ b/clients/js/test/unverifyCollection.test.ts
@@ -61,9 +61,8 @@ test('it can unverify the collection of a minted compressed NFT', async (t) => {
     nonce: leafIndex,
     index: leafIndex,
     metadata: verifiedMetadata,
-  })
-    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
-    .sendAndConfirm(umi);
+    proof: [],
+  }).sendAndConfirm(umi);
 
   // Then the leaf was updated in the merkle tree.
   const updatedLeaf = hashLeaf(umi, {

--- a/clients/js/test/unverifyCreator.test.ts
+++ b/clients/js/test/unverifyCreator.test.ts
@@ -69,9 +69,8 @@ test('it can unverify the creator of a minted compressed NFT', async (t) => {
     ...commonArgs,
     creator: creatorA,
     metadata: verifiedMetadata,
-  })
-    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
-    .sendAndConfirm(umi);
+    proof: [],
+  }).sendAndConfirm(umi);
 
   // Then the leaf was updated in the merkle tree.
   const updatedLeaf = hashLeaf(umi, {

--- a/clients/js/test/verifyCollection.test.ts
+++ b/clients/js/test/verifyCollection.test.ts
@@ -52,9 +52,8 @@ test('it can verify the collection of a minted compressed NFT', async (t) => {
     nonce: leafIndex,
     index: leafIndex,
     metadata,
-  })
-    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
-    .sendAndConfirm(umi);
+    proof: [],
+  }).sendAndConfirm(umi);
 
   // Then the leaf was updated in the merkle tree.
   const updatedLeaf = hashLeaf(umi, {

--- a/clients/js/test/verifyCreator.test.ts
+++ b/clients/js/test/verifyCreator.test.ts
@@ -36,9 +36,8 @@ test('it can verify the creator of a minted compressed NFT', async (t) => {
     nonce: leafIndex,
     index: leafIndex,
     metadata,
-  })
-    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
-    .sendAndConfirm(umi);
+    proof: [],
+  }).sendAndConfirm(umi);
 
   // Then the leaf was updated in the merkle tree.
   const updatedLeaf = hashLeaf(umi, {

--- a/clients/js/test/verifyLeaf.test.ts
+++ b/clients/js/test/verifyLeaf.test.ts
@@ -17,9 +17,8 @@ test('it can verify a leaf on the merkle tree', async (t) => {
     root: getCurrentRoot(merkleTreeAccount.tree),
     leaf: publicKeyBytes(leaf),
     index: leafIndex,
-  })
-    .addRemainingAccounts([]) // <- Proof nodes would be added as remaining accounts.
-    .sendAndConfirm(umi);
+    proof: [],
+  }).sendAndConfirm(umi);
 
   // Then the transaction was successful.
   t.pass();

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -332,6 +332,42 @@ kinobi.update(
         });
       },
     },
+    {
+      // Use extra "proof" arg as remaining accounts.
+      selector: (node) =>
+        k.isInstructionNode(node) &&
+        [
+          "burn",
+          "transfer",
+          "redeem",
+          "setAndVerifyCollection",
+          "verifyCollection",
+          "unverifyCollection",
+          "verifyCreator",
+          "unverifyCreator",
+          "verifyLeaf",
+        ].includes(node.name),
+      transformer: (node) => {
+        k.assertInstructionNode(node);
+        return k.instructionNode({
+          ...node,
+          argDefaults: {
+            ...node.argDefaults,
+            proof: k.valueDefault(k.vList([])),
+          },
+          extraArgs: k.instructionExtraArgsNode({
+            ...node.extraArgs,
+            struct: k.structTypeNode([
+              ...node.extraArgs.struct.fields,
+              k.structFieldTypeNode({
+                name: "proof",
+                child: k.arrayTypeNode(k.publicKeyTypeNode()),
+              }),
+            ]),
+          }),
+        });
+      },
+    },
   ])
 );
 

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -340,6 +340,7 @@ kinobi.update(
           "burn",
           "transfer",
           "redeem",
+          "delegate",
           "setAndVerifyCollection",
           "verifyCollection",
           "unverifyCollection",

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -351,6 +351,7 @@ kinobi.update(
         k.assertInstructionNode(node);
         return k.instructionNode({
           ...node,
+          remainingAccounts: k.remainingAccountsFromArg("proof"),
           argDefaults: {
             ...node.argDefaults,
             proof: k.valueDefault(k.vList([])),

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "validator:stop": "amman stop"
   },
   "devDependencies": {
-    "@metaplex-foundation/kinobi": "^0.11.1",
-    "@metaplex-foundation/shank-js": "^0.1.0",
+    "@metaplex-foundation/kinobi": "^0.12.2",
+    "@metaplex-foundation/shank-js": "^0.1.1",
     "@metaplex-foundation/amman": "^0.12.1",
     "typescript": "^4.9.4"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "validator:stop": "amman stop"
   },
   "devDependencies": {
-    "@metaplex-foundation/kinobi": "^0.12.2",
+    "@metaplex-foundation/kinobi": "^0.12.3",
     "@metaplex-foundation/shank-js": "^0.1.1",
     "@metaplex-foundation/amman": "^0.12.1",
     "typescript": "^4.9.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,11 @@ devDependencies:
     specifier: ^0.12.1
     version: 0.12.1(typescript@4.9.5)
   '@metaplex-foundation/kinobi':
-    specifier: ^0.11.1
-    version: 0.11.1
+    specifier: ^0.12.2
+    version: 0.12.2
   '@metaplex-foundation/shank-js':
-    specifier: ^0.1.0
-    version: 0.1.0
+    specifier: ^0.1.1
+    version: 0.1.1
   typescript:
     specifier: ^4.9.4
     version: 4.9.5
@@ -85,8 +85,8 @@ packages:
     resolution: {integrity: sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA==}
     dev: true
 
-  /@metaplex-foundation/kinobi@0.11.1:
-    resolution: {integrity: sha512-khRJA/2I9Capfj9vMrsPTFOTHWN9H1YPv8EOyELXgLkLRVlVZH0z88Ge/zzl2JqCTZpz1IOWJU1XfJYwiDamjQ==}
+  /@metaplex-foundation/kinobi@0.12.2:
+    resolution: {integrity: sha512-WWCXRHlhiLh2wWbrPandAdn7wr5dXX4gBGRxpTK+U9n6SFbTzO8DRxSbQfWhMWu7Seqh6y/GAKQJho31cNcRAg==}
     dependencies:
       '@noble/hashes': 1.3.0
       chalk: 4.1.2
@@ -107,8 +107,8 @@ packages:
       - supports-color
     dev: true
 
-  /@metaplex-foundation/shank-js@0.1.0:
-    resolution: {integrity: sha512-ExTOIIZFJw8WNHfv+anJifP6/Al9gcWJaUXMifGOB6BxV/J0+jfMg13sm0uMlovU7/tiZSPboS09HXnKaykETg==}
+  /@metaplex-foundation/shank-js@0.1.1:
+    resolution: {integrity: sha512-po19xwO8v3JTVnfY674F2YzGnwA6kc2nHodVEfStbQezfeA6enetwPP956ZKwHaH3/XVKyxT3PLD/ynFcKb7oA==}
     dependencies:
       '@metaplex-foundation/rustbin': 0.3.1
       ansi-colors: 4.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ devDependencies:
     specifier: ^0.12.1
     version: 0.12.1(typescript@4.9.5)
   '@metaplex-foundation/kinobi':
-    specifier: ^0.12.2
-    version: 0.12.2
+    specifier: ^0.12.3
+    version: 0.12.3
   '@metaplex-foundation/shank-js':
     specifier: ^0.1.1
     version: 0.1.1
@@ -85,8 +85,8 @@ packages:
     resolution: {integrity: sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA==}
     dev: true
 
-  /@metaplex-foundation/kinobi@0.12.2:
-    resolution: {integrity: sha512-WWCXRHlhiLh2wWbrPandAdn7wr5dXX4gBGRxpTK+U9n6SFbTzO8DRxSbQfWhMWu7Seqh6y/GAKQJho31cNcRAg==}
+  /@metaplex-foundation/kinobi@0.12.3:
+    resolution: {integrity: sha512-Qr4wKY65YDMoMfSKlIHIMdyOE5E8b9twnn96CadOOU6OHgiHWwVMu6YPgdOG6IVr20IoIWxwkQ+y7fa4dm7+Ng==}
     dependencies:
       '@noble/hashes': 1.3.0
       chalk: 4.1.2


### PR DESCRIPTION
This PR uses the latest version of Kinobi to provide the proof of a leaf by providing a `proof` argument rather than having to add remaining accounts.

Additionally, it:
- Adds a test using a tree big enough that a proof is required.
- Install the `merkletreejs` library for easy proof and root computation.
- Adds a few helpers like `getMerkleRoot` and `getMerkleProof` using the `merkletreejs` library.