### PR TITLE
[Umi] Add getAssetWithProof helper

### DIFF
--- a/clients/js/src/getAssetWithProof.ts
+++ b/clients/js/src/getAssetWithProof.ts
@@ -35,7 +35,7 @@ export const getAssetWithProof = async (
     dataHash: publicKeyBytes(rpcAsset.compression.data_hash),
     creatorHash: publicKeyBytes(rpcAsset.compression.creator_hash),
     nonce: rpcAsset.compression.leaf_id,
-    index: rpcAssetProof.node_index, // TODO: convert to index
+    index: rpcAsset.compression.leaf_id, // TODO: convert rpcAssetProof.node_index to leaf_index using: leaf_index = node_index - 2^tree_height
     proof: rpcAssetProof.proof,
     rpcAsset,
     rpcAssetProof,

--- a/clients/js/src/getAssetWithProof.ts
+++ b/clients/js/src/getAssetWithProof.ts
@@ -1,0 +1,43 @@
+import { Context, PublicKey, publicKeyBytes } from '@metaplex-foundation/umi';
+import { ReadApiInterface } from './readApiDecorator';
+import { GetAssetProofRpcResponse, ReadApiAsset } from './readApiTypes';
+
+export type AssetWithProof = {
+  leafOwner: PublicKey;
+  leafDelegate: PublicKey;
+  merkleTree: PublicKey;
+  root: Uint8Array;
+  dataHash: Uint8Array;
+  creatorHash: Uint8Array;
+  nonce: number;
+  index: number;
+  proof: PublicKey[];
+  rpcAsset: ReadApiAsset;
+  rpcAssetProof: GetAssetProofRpcResponse;
+};
+
+export const getAssetWithProof = async (
+  context: Pick<Context, 'rpc'> & { rpc: ReadApiInterface },
+  assetId: PublicKey
+): Promise<AssetWithProof> => {
+  const [rpcAsset, rpcAssetProof] = await Promise.all([
+    context.rpc.getAsset(assetId),
+    context.rpc.getAssetProof(assetId),
+  ]);
+
+  return {
+    leafOwner: rpcAsset.ownership.owner,
+    leafDelegate: rpcAsset.ownership.delegate
+      ? rpcAsset.ownership.delegate
+      : rpcAsset.ownership.owner,
+    merkleTree: rpcAssetProof.tree_id,
+    root: publicKeyBytes(rpcAssetProof.root),
+    dataHash: publicKeyBytes(rpcAsset.compression.data_hash),
+    creatorHash: publicKeyBytes(rpcAsset.compression.creator_hash),
+    nonce: rpcAsset.compression.leaf_id,
+    index: rpcAssetProof.node_index, // TODO: convert to index
+    proof: rpcAssetProof.proof,
+    rpcAsset,
+    rpcAssetProof,
+  };
+};

--- a/clients/js/src/getAssetWithProof.ts
+++ b/clients/js/src/getAssetWithProof.ts
@@ -35,7 +35,7 @@ export const getAssetWithProof = async (
     dataHash: publicKeyBytes(rpcAsset.compression.data_hash),
     creatorHash: publicKeyBytes(rpcAsset.compression.creator_hash),
     nonce: rpcAsset.compression.leaf_id,
-    index: rpcAsset.compression.leaf_id, // TODO: convert rpcAssetProof.node_index to leaf_index using: leaf_index = node_index - 2^tree_height
+    index: rpcAssetProof.node_index - 2 ** rpcAssetProof.proof.length,
     proof: rpcAssetProof.proof,
     rpcAsset,
     rpcAssetProof,

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -1,6 +1,7 @@
 export * from './createTree';
 export * from './errors';
 export * from './generated';
+export * from './getAssetWithProof';
 export * from './hash';
 export * from './hooked';
 export * from './leafAssetId';

--- a/clients/js/test/transfer.test.ts
+++ b/clients/js/test/transfer.test.ts
@@ -1,8 +1,12 @@
-import { generateSigner, publicKey } from '@metaplex-foundation/umi';
+import { PublicKey, generateSigner, publicKey } from '@metaplex-foundation/umi';
 import test from 'ava';
 import {
+  GetAssetProofRpcResponse,
+  ReadApiAsset,
   delegate,
   fetchMerkleTree,
+  findLeafAssetIdPda,
+  getAssetWithProof,
   getCurrentRoot,
   getMerkleProof,
   hashLeaf,
@@ -167,4 +171,75 @@ test('it can transfer a compressed NFT using a proof', async (t) => {
     proof: updatedProof,
   }).sendAndConfirm(umi);
   t.pass();
+});
+
+test('it can transfer a compressed NFT using the getAssetWithProof helper', async (t) => {
+  // Given we increase the timeout for this test.
+  t.timeout(20000);
+
+  // And given a tree with several minted NFTs so that the proof is required.
+  const umi = await createUmi();
+  const merkleTree = await createTree(umi, { maxDepth: 5, maxBufferSize: 8 });
+  const preMints = [
+    await mint(umi, { merkleTree, leafIndex: 0 }),
+    await mint(umi, { merkleTree, leafIndex: 1 }),
+    await mint(umi, { merkleTree, leafIndex: 2 }),
+    await mint(umi, { merkleTree, leafIndex: 3 }),
+    await mint(umi, { merkleTree, leafIndex: 4 }),
+    await mint(umi, { merkleTree, leafIndex: 5 }),
+    await mint(umi, { merkleTree, leafIndex: 6 }),
+    await mint(umi, { merkleTree, leafIndex: 7 }),
+  ];
+
+  // And a 9th minted NFT owned by leafOwnerA.
+  const leafOwnerA = generateSigner(umi);
+  const { metadata, leaf, leafIndex } = await mint(umi, {
+    merkleTree,
+    leafOwner: leafOwnerA.publicKey,
+    leafIndex: 8,
+  });
+
+  // And given we mock the RPC client to return the following asset and proof.
+  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  const [assetId] = findLeafAssetIdPda(umi, { merkleTree, leafIndex });
+  const rpcAsset = {
+    ownership: { owner: leafOwnerA.publicKey },
+    compression: {
+      leaf_id: leafIndex,
+      data_hash: publicKey(hashMetadataData(metadata)),
+      creator_hash: publicKey(hashMetadataCreators(metadata.creators)),
+    },
+  } as ReadApiAsset;
+  const rpcAssetProof = {
+    proof: getMerkleProof([...preMints.map((m) => m.leaf), leaf], 5, leaf),
+    root: publicKey(getCurrentRoot(merkleTreeAccount.tree)),
+    tree_id: merkleTree,
+    node_index: leafIndex + 2 ** 5,
+  } as GetAssetProofRpcResponse;
+  umi.rpc = {
+    ...umi.rpc,
+    getAsset: async (givenAssetId: PublicKey) => {
+      t.is(givenAssetId, assetId);
+      return rpcAsset;
+    },
+    getAssetProof: async (givenAssetId: PublicKey) => {
+      t.is(givenAssetId, assetId);
+      return rpcAssetProof;
+    },
+  };
+
+  // When we use the getAssetWithProof helper.
+  const assetWithProof = await getAssetWithProof(umi, assetId);
+
+  // Then leafOwnerA can use it to transfer the NFT to leafOwnerB.
+  const leafOwnerB = generateSigner(umi);
+  await transfer(umi, {
+    ...assetWithProof,
+    leafOwner: leafOwnerA,
+    newLeafOwner: leafOwnerB.publicKey,
+  }).sendAndConfirm(umi);
+
+  // And the full asset and proof responses can be retrieved.
+  t.is(assetWithProof.rpcAsset, rpcAsset);
+  t.is(assetWithProof.rpcAssetProof, rpcAssetProof);
 });


### PR DESCRIPTION
This is a stacked PR based on #24. Make sure to merge the base PR first (without squashing) before merging this one.

---

This PR adds a `getAssetWithProof` helper method that fetch both the asset and its proof in parallel using the `umi.rpc.getAsset` and `umi.rpc.getAssetProof` respectively.

It then shapes the RPC responses of these two calls in a way that can be directly use within operation that replace leaves.

Therefore, instead of doing something like this:

```ts
const rpcAsset = await umi.rpc.getAsset(assetId);
const rpcAssetProof = await umi.rpc.getAssetProof(assetId);

await transfer(umi, {
  leafOwner: leafOwnerA,
  newLeafOwner: leafOwnerB.publicKey,
  merkleTree: rpcAssetProof.tree_id,
  root: publicKeyBytes(rpcAssetProof.root),
  dataHash: publicKeyBytes(rpcAsset.compression.data_hash),
  creatorHash: publicKeyBytes(rpcAsset.compression.creator_hash),
  nonce: rpcAsset.compression.leaf_id,
  index: rpcAssetProof.node_index - 2 ** rpcAssetProof.proof.length,
  proof: rpcAssetProof.proof,
}).sendAndConfirm(umi);
```

We can now simplify it like so:

```ts
const assetWithProof = await getAssetWithProof(umi, assetId);

await transfer(umi, {
  ...assetWithProof,
  leafOwner: leafOwnerA,
  newLeafOwner: leafOwnerB.publicKey,
}).sendAndConfirm(umi);
```