### PR TITLE
Add Metadata to getAssetWithProof helper

### DIFF
--- a/clients/js/src/getAssetWithProof.ts
+++ b/clients/js/src/getAssetWithProof.ts
@@ -35,18 +35,18 @@ export const getAssetWithProof = async (
     context.rpc.getAssetProof(assetId),
   ]);
 
-  const collectionString = rpcAsset.grouping.find(
+  const collectionString = (rpcAsset.grouping ?? []).find(
     (group) => group.group_key === 'collection'
   )?.group_value;
 
   const metadata: MetadataArgs = {
-    name: rpcAsset.content.metadata.name ?? '',
-    symbol: rpcAsset.content.metadata.symbol ?? '',
-    uri: rpcAsset.content.json_uri,
-    sellerFeeBasisPoints: rpcAsset.royalty.basis_points,
-    primarySaleHappened: rpcAsset.royalty.primary_sale_happened,
+    name: rpcAsset.content?.metadata?.name ?? '',
+    symbol: rpcAsset.content?.metadata?.symbol ?? '',
+    uri: rpcAsset.content?.json_uri,
+    sellerFeeBasisPoints: rpcAsset.royalty?.basis_points,
+    primarySaleHappened: rpcAsset.royalty?.primary_sale_happened,
     isMutable: rpcAsset.mutable,
-    editionNonce: wrapNullable(rpcAsset.supply.edition_nonce),
+    editionNonce: wrapNullable(rpcAsset.supply?.edition_nonce),
     tokenStandard: some(TokenStandard.NonFungible),
     collection: collectionString
       ? some({ key: publicKey(collectionString), verified: true })

--- a/clients/js/src/getAssetWithProof.ts
+++ b/clients/js/src/getAssetWithProof.ts
@@ -1,4 +1,13 @@
-import { Context, PublicKey, publicKeyBytes } from '@metaplex-foundation/umi';
+import {
+  Context,
+  PublicKey,
+  none,
+  publicKey,
+  publicKeyBytes,
+  some,
+  wrapNullable,
+} from '@metaplex-foundation/umi';
+import { MetadataArgs, TokenProgramVersion, TokenStandard } from './generated';
 import { ReadApiInterface } from './readApiDecorator';
 import { GetAssetProofRpcResponse, ReadApiAsset } from './readApiTypes';
 
@@ -12,6 +21,7 @@ export type AssetWithProof = {
   nonce: number;
   index: number;
   proof: PublicKey[];
+  metadata: MetadataArgs;
   rpcAsset: ReadApiAsset;
   rpcAssetProof: GetAssetProofRpcResponse;
 };
@@ -25,6 +35,27 @@ export const getAssetWithProof = async (
     context.rpc.getAssetProof(assetId),
   ]);
 
+  const collectionString = rpcAsset.grouping.find(
+    (group) => group.group_key === 'collection'
+  )?.group_value;
+
+  const metadata: MetadataArgs = {
+    name: rpcAsset.content.metadata.name ?? '',
+    symbol: rpcAsset.content.metadata.symbol ?? '',
+    uri: rpcAsset.content.json_uri,
+    sellerFeeBasisPoints: rpcAsset.royalty.basis_points,
+    primarySaleHappened: rpcAsset.royalty.primary_sale_happened,
+    isMutable: rpcAsset.mutable,
+    editionNonce: wrapNullable(rpcAsset.supply.edition_nonce),
+    tokenStandard: some(TokenStandard.NonFungible),
+    collection: collectionString
+      ? some({ key: publicKey(collectionString), verified: true })
+      : none(),
+    uses: none(),
+    tokenProgramVersion: TokenProgramVersion.Original,
+    creators: rpcAsset.creators,
+  };
+
   return {
     leafOwner: rpcAsset.ownership.owner,
     leafDelegate: rpcAsset.ownership.delegate
@@ -37,6 +68,7 @@ export const getAssetWithProof = async (
     nonce: rpcAsset.compression.leaf_id,
     index: rpcAssetProof.node_index - 2 ** rpcAssetProof.proof.length,
     proof: rpcAssetProof.proof,
+    metadata,
     rpcAsset,
     rpcAssetProof,
   };


### PR DESCRIPTION
This PR adds a `metadata` attribute compatible with the `MetadataArgs` type to the return object of the `getAssetWithProof` helper function. This is because it, in some cases, instructions require that `MetadataArgs` object to be provided — e.g. when decompressing.

However, this is tricky to retrieve purely from the Read API as some of the data is lost from the original `MetadataArgs` object that was provided upon creation. For instance, we can only retrieve the `name` of the `MetadataArgs` from the JSON metadata which may differ from the original `name` attribute that was given upon creation. Another example is the collection attribute which is transformed into a `groups` object and the `verified` attribute is lost.

**EDIT**: As discussed with @danenbm, some of these fields are actually being aggregated from both the on-chain and off-chain data so this solution is a bit more robust than anticipated. However, the plan is to eventually reliably offer the latest `MetadataArgs` object in the response of the `getAsset` RPC response — inside the `compression` object.