### PR TITLE
Allow tree authority to be passed a Signer for setAndVerifyCollection

### DIFF
--- a/clients/js/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js/src/generated/instructions/setAndVerifyCollection.ts
@@ -52,7 +52,7 @@ export type SetAndVerifyCollectionInstructionAccounts = {
    * we are actually changing the NFT metadata.
    */
 
-  treeCreatorOrDelegate?: PublicKey | Pda;
+  treeCreatorOrDelegate?: PublicKey | Pda | Signer;
   collectionAuthority?: Signer;
   /**
    * If there is no collecton authority record PDA then
@@ -202,7 +202,7 @@ export function setAndVerifyCollection(
     'treeCreatorOrDelegate',
     input.treeCreatorOrDelegate
       ? ([input.treeCreatorOrDelegate, false] as const)
-      : ([context.identity.publicKey, false] as const)
+      : ([context.identity, false] as const)
   );
   addObjectProperty(
     resolvedAccounts,

--- a/clients/js/test/setAndVerifyCollection.test.ts
+++ b/clients/js/test/setAndVerifyCollection.test.ts
@@ -4,6 +4,7 @@ import {
   percentAmount,
   publicKey,
 } from '@metaplex-foundation/umi';
+import { generateSignerWithSol } from '@metaplex-foundation/umi-bundle-tests';
 import test from 'ava';
 import {
   fetchMerkleTree,
@@ -28,14 +29,20 @@ test('it can set and verify the collection of a minted compressed NFT', async (t
   }).sendAndConfirm(umi);
 
   // And a tree with a minted NFT that has no collection.
-  const merkleTree = await createTree(umi);
+  const treeCreator = await generateSignerWithSol(umi);
+  const merkleTree = await createTree(umi, { treeCreator });
   let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
-  const { metadata, leafIndex } = await mint(umi, { merkleTree, leafOwner });
+  const { metadata, leafIndex } = await mint(umi, {
+    merkleTree,
+    treeCreatorOrDelegate: treeCreator,
+    leafOwner,
+  });
 
   // When the collection authority sets and verifies the collection.
   await setAndVerifyCollection(umi, {
     leafOwner,
+    treeCreatorOrDelegate: treeCreator,
     collectionMint: collectionMint.publicKey,
     collectionAuthority,
     merkleTree,
@@ -61,4 +68,48 @@ test('it can set and verify the collection of a minted compressed NFT', async (t
   });
   merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(updatedLeaf));
+});
+
+test('it cannot set and verify the collection if the tree creator or delegate does not sign', async (t) => {
+  // Given a Collection NFT.
+  const umi = await createUmi();
+  const collectionMint = generateSigner(umi);
+  const collectionAuthority = generateSigner(umi);
+  await createNft(umi, {
+    mint: collectionMint,
+    authority: collectionAuthority,
+    name: 'My Collection',
+    uri: 'https://example.com/my-collection.json',
+    sellerFeeBasisPoints: percentAmount(5.5), // 5.5%
+    isCollection: true,
+  }).sendAndConfirm(umi);
+
+  // And a tree with a minted NFT that has no collection.
+  const treeCreator = await generateSignerWithSol(umi);
+  const merkleTree = await createTree(umi, { treeCreator });
+  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  const leafOwner = generateSigner(umi).publicKey;
+  const { metadata, leafIndex } = await mint(umi, {
+    merkleTree,
+    treeCreatorOrDelegate: treeCreator,
+    leafOwner,
+  });
+
+  // When the collection authority sets and verifies the collection
+  // without the tree creator signing.
+  const promise = setAndVerifyCollection(umi, {
+    leafOwner,
+    treeCreatorOrDelegate: treeCreator.publicKey, // <-- Here, we pass the tree creator as a public key.
+    collectionMint: collectionMint.publicKey,
+    collectionAuthority,
+    merkleTree,
+    root: getCurrentRoot(merkleTreeAccount.tree),
+    nonce: leafIndex,
+    index: leafIndex,
+    metadata,
+    proof: [],
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'UpdateAuthorityIncorrect' });
 });

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -252,6 +252,9 @@ kinobi.update(
       },
     },
     setAndVerifyCollection: {
+      accounts: {
+        treeCreatorOrDelegate: { isSigner: "either" },
+      },
       args: {
         ...hashDefaults,
         collection: {


### PR DESCRIPTION
### Context
When using the `setAndVerifyCollection` instruction, the `treeCreatorOrDelegate` account must be passed as an account if it differs from the collection's update authority.

### Problem
The `treeCreatorOrDelegate` account can only be passed as a `PublicKey`. The current test is passing because the `treeCreatorOrDelegate` is the Umi identity and therefore set as the `payer` by default which ultimately makes the `treeCreatorOrDelegate` a signer account.

### Solution
This PR allows users to provide the `treeCreatorOrDelegate` account as a `PublicKey` or a `Signer` by using the `isSigner: "either"` mode in Kinobi.

It updates the existing test so both the `treeCreatorOrDelegate` and `collectionAuthority` are explicit wallets, distinct from Umi's identity to avoid side effects. It also adds a test that ensure we receive a `UpdateAuthorityIncorrect` error when the `treeCreatorOrDelegate` is not a signer and differs from the collection authority.