### PR TITLE
Use solana 1.14 for deploy

### DIFF
--- a/.github/.env
+++ b/.github/.env
@@ -4,6 +4,5 @@ PROGRAMS=["bubblegum"]
 RUST_VERSION=1.68.0
 SOLANA_VERSION=1.16.5
 ANCHOR_VERSION=0.27.0
-SOLANA_CLI_VERSION=1.14.22
 COMMIT_USER_NAME="github-actions[bot]"
 COMMIT_USER_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/.env
+++ b/.github/.env
@@ -4,5 +4,6 @@ PROGRAMS=["bubblegum"]
 RUST_VERSION=1.68.0
 SOLANA_VERSION=1.16.5
 ANCHOR_VERSION=0.27.0
+SOLANA_CLI_VERSION=1.14.22
 COMMIT_USER_NAME="github-actions[bot]"
 COMMIT_USER_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/deploy-program.yml
+++ b/.github/workflows/deploy-program.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install Solana
         uses: metaplex-foundation/actions/install-solana@v1
         with:
-          version: ${{ env.SOLANA_VERSION }}
+          version: ${{ env.SOLANA_CLI_VERSION }}
           cache: ${{ env.CACHE }}
 
       - name: Install Anchor CLI

--- a/.github/workflows/deploy-program.yml
+++ b/.github/workflows/deploy-program.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install Solana
         uses: metaplex-foundation/actions/install-solana@v1
         with:
-          version: ${{ env.SOLANA_CLI_VERSION }}
+          version: "1.14.22"
           cache: ${{ env.CACHE }}
 
       - name: Install Anchor CLI


### PR DESCRIPTION
Solana `1.16.x` currently has issues deploying programs, which can take significantly longer than usual and lead to timeout errors. This PR changes the solana version for deploy to `1.14.22` to mitigate this.