### PR TITLE
Update Kaigan and Borsh

### DIFF
--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -2268,7 +2268,7 @@ name = "mpl-bubblegum"
 version = "1.0.0"
 dependencies = [
  "assert_matches",
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "bytemuck",
  "kaigan",
  "num-derive",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -16,8 +16,8 @@ test-sbf = []
 serde = ["dep:serde", "dep:serde_with", "kaigan/serde"]
 
 [dependencies]
-borsh = ">= 0.9"
-kaigan = ">= 0.1"
+borsh = ">= 0.10"
+kaigan = ">= 0.2"
 num-derive = "^0.3"
 num-traits = "^0.2"
 serde = { version = "^1.0", features = ["derive"], optional = true }


### PR DESCRIPTION
Fix for:
```
  --> src/generated/accounts/merkle_tree.rs:14:10
   |
14 | #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
   |          ^^^^^^^^^^^^^^ the trait `borsh::BorshSerialize` is not implemented for `kaigan::types::RemainderVec<u8>`
   |
   = help: the following other types implement trait `borsh::BorshSerialize`:
             &T
             ()
             (T0, T1)
             (T0, T1, T2)
             (T0, T1, T2, T3)
             (T0, T1, T2, T3, T4)
             (T0, T1, T2, T3, T4, T5)
             (T0, T1, T2, T3, T4, T5, T6)
           and 136 others
   = help: see issue #48214
   = note: this error originates in the derive macro `BorshSerialize` (in Nightly builds, run with -Z macro-backtrace for more info)
```

I thnk updating Borsh might also just fix it.