### PR TITLE
Update metadata Umi tests

### DIFF
--- a/clients/js/src/generated/instructions/updateMetadata.ts
+++ b/clients/js/src/generated/instructions/updateMetadata.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findMetadataPda } from '@metaplex-foundation/mpl-token-metadata';
 import {
   Context,
   Pda,
@@ -198,6 +199,13 @@ export function updateMetadata(
   }
   if (!resolvedAccounts.authority.value) {
     resolvedAccounts.authority.value = context.identity;
+  }
+  if (!resolvedAccounts.collectionMetadata.value) {
+    if (resolvedAccounts.collectionMint.value) {
+      resolvedAccounts.collectionMetadata.value = findMetadataPda(context, {
+        mint: expectPublicKey(resolvedAccounts.collectionMint.value),
+      });
+    }
   }
   if (!resolvedAccounts.leafDelegate.value) {
     resolvedAccounts.leafDelegate.value = expectSome(

--- a/clients/js/test/updateMetadata.test.ts
+++ b/clients/js/test/updateMetadata.test.ts
@@ -9,12 +9,12 @@ import {
 import test from 'ava';
 import {
   MetadataArgsArgs,
+  UpdateArgsArgs,
   fetchMerkleTree,
   getCurrentRoot,
   hashLeaf,
   updateMetadata,
   mintV1,
-  UpdateArgs,
   findLeafAssetIdPda,
   getAssetWithProof,
   getMerkleProof,
@@ -66,14 +66,9 @@ test('it update the metadata of a minted compressed NFT', async (t) => {
   t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(leaf));
 
   // And when metadata is updated.
-  const update_args: UpdateArgs = {
+  const updateArgs: UpdateArgsArgs = {
     name: some('New name'),
-    symbol: none(),
     uri: some('https://updated-example.com/my-nft.json'),
-    creators: none(),
-    sellerFeeBasisPoints: none(),
-    primarySaleHappened: none(),
-    isMutable: none(),
   };
 
   await updateMetadata(umi, {
@@ -84,7 +79,7 @@ test('it update the metadata of a minted compressed NFT', async (t) => {
     index: 0,
     currentMetadata: metadata,
     proof: [],
-    updateArgs: update_args,
+    updateArgs,
   }).sendAndConfirm(umi);
 
   // Then the leaf was updated in the merkle tree.
@@ -159,20 +154,15 @@ test('it can update metadata using the getAssetWithProof helper', async (t) => {
   const assetWithProof = await getAssetWithProof(umi, assetId);
 
   // Then we can use it to update metadata for the NFT.
-  const update_args: UpdateArgs = {
+  const updateArgs: UpdateArgsArgs = {
     name: some('New name'),
-    symbol: none(),
     uri: some('https://updated-example.com/my-nft.json'),
-    creators: none(),
-    sellerFeeBasisPoints: none(),
-    primarySaleHappened: none(),
-    isMutable: none(),
   };
 
   await updateMetadata(umi, {
     ...assetWithProof,
     currentMetadata: metadata,
-    updateArgs: update_args,
+    updateArgs,
   }).sendAndConfirm(umi);
 
   // And the full asset and proof responses can be retrieved.

--- a/clients/js/test/updateMetadata.test.ts
+++ b/clients/js/test/updateMetadata.test.ts
@@ -295,9 +295,6 @@ test('it can update metadata using collection update authority when collection i
     updateArgs,
     authority: collectionAuthority,
     collectionMint: collectionMint.publicKey,
-    collectionMetadata: findMetadataPda(umi, {
-      mint: collectionMint.publicKey,
-    }),
   }).sendAndConfirm(umi);
 
   // Then the leaf was updated in the merkle tree.
@@ -371,9 +368,6 @@ test('it cannot update metadata using tree owner when collection is verified', a
     updateArgs,
     authority: treeCreator,
     collectionMint: collectionMint.publicKey,
-    collectionMetadata: findMetadataPda(umi, {
-      mint: collectionMint.publicKey,
-    }),
   }).sendAndConfirm(umi);
 
   // Then we expect a program error.

--- a/clients/js/test/updateMetadata.test.ts
+++ b/clients/js/test/updateMetadata.test.ts
@@ -1,0 +1,93 @@
+import {
+  defaultPublicKey,
+  generateSigner,
+  none,
+  some,
+  publicKey,
+} from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  MetadataArgsArgs,
+  fetchMerkleTree,
+  getCurrentRoot,
+  hashLeaf,
+  updateMetadata,
+  mintV1,
+  UpdateArgs,
+} from '../src';
+import { createTree, createUmi } from './_setup';
+
+test('it update the metadata of a minted compressed NFT', async (t) => {
+  // Given an empty Bubblegum tree.
+  const umi = await createUmi();
+  const merkleTree = await createTree(umi);
+  const leafOwner = generateSigner(umi).publicKey;
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.sequenceNumber, 0n);
+  t.is(merkleTreeAccount.tree.activeIndex, 0n);
+  t.is(merkleTreeAccount.tree.bufferSize, 1n);
+  t.is(merkleTreeAccount.tree.rightMostPath.index, 0);
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, defaultPublicKey());
+
+  // When we mint a new NFT from the tree using the following metadata.
+  const metadata: MetadataArgsArgs = {
+    name: 'My NFT',
+    uri: 'https://example.com/my-nft.json',
+    sellerFeeBasisPoints: 500, // 5%
+    collection: none(),
+    creators: [],
+  };
+  await mintV1(umi, { leafOwner, merkleTree, metadata }).sendAndConfirm(umi);
+
+  // Then a new leaf was added to the merkle tree.
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.sequenceNumber, 1n);
+  t.is(merkleTreeAccount.tree.activeIndex, 1n);
+  t.is(merkleTreeAccount.tree.bufferSize, 2n);
+  t.is(merkleTreeAccount.tree.rightMostPath.index, 1);
+
+  // And the hash of the metadata matches the new leaf.
+  const leaf = hashLeaf(umi, {
+    merkleTree,
+    owner: leafOwner,
+    leafIndex: 0,
+    metadata,
+  });
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(leaf));
+
+  // And when metadata is updated.
+  const update_args: UpdateArgs = {
+    name: some('New name'),
+    symbol: none(),
+    uri: some('https://updated-example.com/my-nft.json'),
+    creators: none(),
+    sellerFeeBasisPoints: none(),
+    primarySaleHappened: none(),
+    isMutable: none(),
+  };
+
+  await updateMetadata(umi, {
+    leafOwner,
+    merkleTree,
+    root: getCurrentRoot(merkleTreeAccount.tree),
+    nonce: 0,
+    index: 0,
+    currentMetadata: metadata,
+    //proof: [],
+    updateArgs: update_args,
+  }).sendAndConfirm(umi);
+
+  // Then the leaf was updated in the merkle tree.
+  const updatedLeaf = hashLeaf(umi, {
+    merkleTree,
+    owner: leafOwner,
+    leafIndex: 0,
+    metadata: {
+      ...metadata,
+      name: 'New name',
+      uri: 'https://updated-example.com/my-nft.json',
+    },
+  });
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(updatedLeaf));
+});

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -419,6 +419,7 @@ kinobi.update(
           "verifyCreator",
           "unverifyCreator",
           "verifyLeaf",
+          "updateMetadata"
         ].includes(node.name),
       transformer: (node) => {
         k.assertInstructionNode(node);

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -453,6 +453,23 @@ kinobi.update(
   ])
 );
 
+kinobi.update(
+  new k.UpdateInstructionsVisitor({
+    updateMetadata: {
+      accounts: {
+        collectionMetadata: {
+          defaultsTo: k.conditionalDefault("account", "collectionMint", {
+            ifTrue: k.pdaDefault("metadata", {
+              importFrom: "mplTokenMetadata",
+              seeds: { mint: k.accountDefault("collectionMint") },
+            }),
+          }),
+        },
+      },
+    },
+  })
+);
+
 // Render JavaScript.
 const jsDir = path.join(clientDir, "js", "src", "generated");
 const prettier = require(path.join(clientDir, "js", ".prettierrc.json"));


### PR DESCRIPTION
Adding the following Umi tests, ported from existing js-solita tests:
* can update the metadata of a minted compressed NFT
* can update metadata using the `getAssetWithProof` helper
* cannot update metadata using collection update authority when collection not verified
* can update metadata using collection update authority when collection is verified
* cannot update metadata using tree owner when collection is verified

I just had to add the `proof` alias to the kinobi config, but other things such as the `UpdateArgsArgs` that has defaults is already set up.

A few more test cases on the way.