### PR TITLE
Allow 0.9.x in addition to 0.8.x for Umi peer dependency

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -32,7 +32,7 @@
     "merkletreejs": "^0.3.9"
   },
   "peerDependencies": {
-    "@metaplex-foundation/umi": "^0.8.9"
+    "@metaplex-foundation/umi": "^0.8.9 | ^0.9.0"
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",


### PR DESCRIPTION
Just to allow more compatibility