### PR TITLE
chore: update pnpm to 8.14.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 .crates
 test-programs
 programs/.bin
+.idea

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "@metaplex-foundation/shank-js": "^0.1.5",
     "typescript": "^4.9.4"
   },
-  "packageManager": "pnpm@8.2.0"
+  "packageManager": "pnpm@8.14.3"
 }


### PR DESCRIPTION
pnpm 8.2.0 has issue which prevents to install dependencies: “ WARN  GET https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz error (ERR_INVALID_THIS). Will retry in 1 minute. 1 retries left.”

See also: https://github.com/pnpm/pnpm/issues/6424