### PR TITLE
Allow 0.8.9 to < 1.0.0 Umi versions

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -32,7 +32,7 @@
     "merkletreejs": "^0.3.9"
   },
   "peerDependencies": {
-    "@metaplex-foundation/umi": "^0.8.9 || ^0.9.0"
+    "@metaplex-foundation/umi": ">= 0.8.9 < 1"
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",


### PR DESCRIPTION
Per Loris advice this will be more flexible for 0.x.x versions in the future.