### PR TITLE
Update SPL AC to v0.3.1

### DIFF
--- a/programs/bubblegum/program/Cargo.toml
+++ b/programs/bubblegum/program/Cargo.toml
@@ -26,7 +26,7 @@ bytemuck = "1.13.0"
 mpl-token-metadata = "3.2.3"
 num-traits = "0.2.15"
 solana-program = "~1.16.8"
-spl-account-compression = { version="0.2.0", features = ["cpi"] }
+spl-account-compression = { version="0.3.1", features = ["cpi"] }
 spl-associated-token-account = { version = ">= 1.1.3, < 3.0", features = ["no-entrypoint"] }
 spl-token = { version = ">= 3.5.0, < 5.0", features = ["no-entrypoint"] }
 


### PR DESCRIPTION
Add support for new tree depth and buffer size pairs for tree initialization