### PR TITLE
Test creating a new tree size from spl-account-compression 0.3.1

### DIFF
--- a/clients/js/test/createTree.test.ts
+++ b/clients/js/test/createTree.test.ts
@@ -31,3 +31,32 @@ test('it can create a Bubblegum tree', async (t) => {
     isPublic: false,
   });
 });
+
+test('it can create a Bubblegum tree using a newer size', async (t) => {
+  // Given a brand new merkle tree signer.
+  const umi = await createUmi();
+  const merkleTree = generateSigner(umi);
+
+  // When we create a tree at this address.
+  const builder = await createTree(umi, {
+    merkleTree,
+    maxDepth: 6,
+    maxBufferSize: 16,
+  });
+  await builder.sendAndConfirm(umi);
+
+  // Then an account exists at the merkle tree address.
+  t.true(await umi.rpc.accountExists(merkleTree.publicKey));
+
+  // And a tree config was created with the correct data.
+  const treeConfig = await fetchTreeConfigFromSeeds(umi, {
+    merkleTree: merkleTree.publicKey,
+  });
+  t.like(treeConfig, <TreeConfig>{
+    treeCreator: publicKey(umi.identity),
+    treeDelegate: publicKey(umi.identity),
+    totalMintCapacity: 2n ** 6n,
+    numMinted: 0n,
+    isPublic: false,
+  });
+});

--- a/clients/rust/tests/mint.rs
+++ b/clients/rust/tests/mint.rs
@@ -23,7 +23,7 @@ mod mint {
 
         // Given a new merkle tree.
 
-        let mut tree_manager = TreeManager::<5, 8>::default();
+        let mut tree_manager = TreeManager::<6, 16>::default();
         tree_manager.create(&mut context).await.unwrap();
 
         assert!(find_account(&mut context, &tree_manager.tree.pubkey())


### PR DESCRIPTION
This simply exercises one of the new tree sizes available in spl-account-compression 0.3.1