### PR TITLE
Add SDK helper to choose compression programs

### DIFF
--- a/clients/js/src/getCompressionPrograms.ts
+++ b/clients/js/src/getCompressionPrograms.ts
@@ -29,14 +29,14 @@ export async function getCompressionPrograms(
   const genesisHash = await context.rpc.call<string>('getGenesisHash');
 
   // Determine if the genesis hash matches known clusters.
-  const isKnownCluster = [
+  const isSolanaCluster = [
     SOLANA_MAINNET_GENESIS_HASH,
     SOLANA_DEVNET_GENESIS_HASH,
     SOLANA_TESTNET_GENESIS_HASH,
   ].includes(genesisHash);
 
   // Return appropriate program IDs based on the cluster.
-  if (isKnownCluster) {
+  if (isSolanaCluster) {
     return {
       logWrapper: SPL_NOOP_PROGRAM_ID,
       compressionProgram: SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,

--- a/clients/js/src/getCompressionPrograms.ts
+++ b/clients/js/src/getCompressionPrograms.ts
@@ -1,0 +1,49 @@
+import { Context, PublicKey } from '@metaplex-foundation/umi';
+import {
+  SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
+  SPL_NOOP_PROGRAM_ID,
+} from './generated';
+
+export const MPL_ACCOUNT_COMPRESSION_PROGRAM_ID =
+  'mcmt6YrQEMKw8Mw43FmpRLmf7BqRnFMKmAcbxE3xkAW' as PublicKey<'mcmt6YrQEMKw8Mw43FmpRLmf7BqRnFMKmAcbxE3xkAW'>;
+
+export const MPL_NOOP_PROGRAM_ID =
+  'mnoopTCrg4p8ry25e4bcWA9XZjbNjMTfgYVGGEdRsf3' as PublicKey<'mnoopTCrg4p8ry25e4bcWA9XZjbNjMTfgYVGGEdRsf3'>;
+
+// Constants for known genesis blockhashes on Solana.
+const SOLANA_MAINNET_GENESIS_HASH =
+  '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d';
+const SOLANA_DEVNET_GENESIS_HASH =
+  'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG';
+const SOLANA_TESTNET_GENESIS_HASH =
+  '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY';
+
+export type CompressionPrograms = {
+  logWrapper: PublicKey;
+  compressionProgram: PublicKey;
+};
+
+export async function getCompressionPrograms(
+  context: Pick<Context, 'programs' | 'eddsa' | 'rpc'>
+): Promise<CompressionPrograms> {
+  const genesisHash = await context.rpc.call<string>('getGenesisHash');
+
+  // Determine if the genesis hash matches known clusters.
+  const isKnownCluster = [
+    SOLANA_MAINNET_GENESIS_HASH,
+    SOLANA_DEVNET_GENESIS_HASH,
+    SOLANA_TESTNET_GENESIS_HASH,
+  ].includes(genesisHash);
+
+  // Return appropriate program IDs based on the cluster.
+  if (isKnownCluster) {
+    return {
+      logWrapper: SPL_NOOP_PROGRAM_ID,
+      compressionProgram: SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
+    };
+  }
+  return {
+    logWrapper: MPL_NOOP_PROGRAM_ID,
+    compressionProgram: MPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
+  };
+}

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -7,3 +7,4 @@ export * from './hooked';
 export * from './leafAssetId';
 export * from './merkle';
 export * from './plugin';
+export * from './getCompressionPrograms';

--- a/clients/js/test/createTree.test.ts
+++ b/clients/js/test/createTree.test.ts
@@ -17,6 +17,9 @@ import {
   safeFetchTreeConfigFromSeeds,
   getMerkleTreeSize,
   SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
+  getCompressionPrograms,
+  MPL_NOOP_PROGRAM_ID,
+  MPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
 } from '../src';
 import { createUmi } from './_setup';
 
@@ -133,15 +136,17 @@ test('it can create a Bubblegum tree using mpl-account-compression and mpl-noop'
   const umi = await createUmi();
   const merkleTree = generateSigner(umi);
 
+  // For these tests, make sure `getCompressionPrograms` doesn't return spl programs.
+  const { logWrapper, compressionProgram } = await getCompressionPrograms(umi);
+  t.is(logWrapper, MPL_NOOP_PROGRAM_ID);
+  t.is(compressionProgram, MPL_ACCOUNT_COMPRESSION_PROGRAM_ID);
+
   // When we create a tree at this address.
   const builder = await createTree(umi, {
     merkleTree,
     maxDepth: 14,
     maxBufferSize: 64,
-    logWrapper: publicKey('mnoopTCrg4p8ry25e4bcWA9XZjbNjMTfgYVGGEdRsf3'),
-    compressionProgram: publicKey(
-      'mcmt6YrQEMKw8Mw43FmpRLmf7BqRnFMKmAcbxE3xkAW'
-    ),
+    ...(await getCompressionPrograms(umi)),
   });
   await builder.sendAndConfirm(umi);
 
@@ -200,9 +205,7 @@ test('it cannot create a Bubblegum tree using invalid logWrapper with mpl-accoun
     maxDepth: 14,
     maxBufferSize: 64,
     logWrapper: generateSigner(umi).publicKey,
-    compressionProgram: publicKey(
-      'mcmt6YrQEMKw8Mw43FmpRLmf7BqRnFMKmAcbxE3xkAW'
-    ),
+    compressionProgram: MPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
   });
 
   const promise = builder.sendAndConfirm(umi);
@@ -262,9 +265,9 @@ test('it cannot create a Bubblegum tree when compression program does not match 
     merkleTree,
     maxDepth: 14,
     maxBufferSize: 64,
-    logWrapper: publicKey('mnoopTCrg4p8ry25e4bcWA9XZjbNjMTfgYVGGEdRsf3'),
+    logWrapper: MPL_NOOP_PROGRAM_ID,
     compressionProgram: generateSigner(umi).publicKey,
-    merkleTreeOwner: publicKey('mcmt6YrQEMKw8Mw43FmpRLmf7BqRnFMKmAcbxE3xkAW'),
+    merkleTreeOwner: MPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
   });
 
   const promise = builder.sendAndConfirm(umi);


### PR DESCRIPTION
### Notes
* If helper is not used, Umi SDK defaults to SPL programs.
* If helper is used, it chooses based on genesis blockhash.

### Testing
* Running tests on local validator pass and is equivalent to running on another SVM because the genesis blockhash doesn't match a known Solana cluster.
* Modified code and ran transfer test on **Eclipse devnet** and **Eclipse mainnet-beta** and in both cases it chose **MPL programs** and worked as expected.
* Modified code and ran transfer test on **Solana devnet** and **Solana mainnet-beta** and in both cases it chose **SPL programs** and worked as expected.