### PR TITLE
Remove upper limit from Rust client Solana version

### DIFF
--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -22,7 +22,7 @@ num-derive = "^0.3"
 num-traits = "^0.2"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_with = { version = "^3.0", optional = true }
-solana-program = "^1.14"
+solana-program = ">= 1.14, < 2.1"
 thiserror = "^1.0"
 
 [dev-dependencies]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -22,7 +22,7 @@ num-derive = "^0.3"
 num-traits = "^0.2"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_with = { version = "^3.0", optional = true }
-solana-program = ">= 1.14, < 2.1"
+solana-program = ">= 1.14"
 thiserror = "^1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
### Notes
* This allows the Rust client to be used with Solana 2.0+.
* It's a workaround until some Solana packages are released with support for Solana 2.x, at which point we could update our dev dependencies/client tests as well.
  * See https://github.com/metaplex-foundation/mpl-bubblegum/pull/125 for the draft.
  * People won't be able to use spl-noop (which they would try to use to get the program ID), so they will have to hard code it.
  * People won't be able to use spl-account-compression 0.4.2 with Solana 2.x because it has an Anchor 0.29 dependency.
  
### Testing
* For now this is an non CI-tested limit removal and our lock file is still using Solana 1.18.23.
* Manually tested with Solana 2.0, and could mint an item.  But my test was painful: I had to manually provide the spl-account-compression and spl-noop program IDs, and calculate the tree size outside of any spl-account-compression types.
