### PR TITLE
Port `getCompressionPrograms` helper from SVM branch

### DIFF
--- a/clients/js/src/createTree.ts
+++ b/clients/js/src/createTree.ts
@@ -27,6 +27,18 @@ export const createTree = async (
     getMerkleTreeSize(input.maxDepth, input.maxBufferSize, input.canopyDepth);
   const lamports = await context.rpc.getRent(space);
 
+  let programId;
+  if (input.compressionProgram) {
+    programId = Array.isArray(input.compressionProgram)
+      ? input.compressionProgram[0]
+      : input.compressionProgram;
+  } else {
+    programId = context.programs.getPublicKey(
+      'splAccountCompression',
+      SPL_ACCOUNT_COMPRESSION_PROGRAM_ID
+    );
+  }
+
   return (
     transactionBuilder()
       // Create the empty Merkle tree account.
@@ -36,10 +48,7 @@ export const createTree = async (
           newAccount: input.merkleTree,
           lamports,
           space,
-          programId: context.programs.getPublicKey(
-            'splAccountCompression',
-            SPL_ACCOUNT_COMPRESSION_PROGRAM_ID
-          ),
+          programId,
         })
       )
       // Create the tree config.

--- a/clients/js/src/createTree.ts
+++ b/clients/js/src/createTree.ts
@@ -5,6 +5,7 @@ import {
   Signer,
   TransactionBuilder,
   transactionBuilder,
+  publicKey,
 } from '@metaplex-foundation/umi';
 import {
   SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
@@ -27,17 +28,12 @@ export const createTree = async (
     getMerkleTreeSize(input.maxDepth, input.maxBufferSize, input.canopyDepth);
   const lamports = await context.rpc.getRent(space);
 
-  let programId;
-  if (input.compressionProgram) {
-    programId = Array.isArray(input.compressionProgram)
-      ? input.compressionProgram[0]
-      : input.compressionProgram;
-  } else {
-    programId = context.programs.getPublicKey(
-      'splAccountCompression',
-      SPL_ACCOUNT_COMPRESSION_PROGRAM_ID
-    );
-  }
+  const programId = input.compressionProgram
+    ? publicKey(input.compressionProgram)
+    : context.programs.getPublicKey(
+        'splAccountCompression',
+        SPL_ACCOUNT_COMPRESSION_PROGRAM_ID
+      );
 
   return (
     transactionBuilder()

--- a/clients/js/src/getCompressionPrograms.ts
+++ b/clients/js/src/getCompressionPrograms.ts
@@ -1,0 +1,49 @@
+import { Context, PublicKey } from '@metaplex-foundation/umi';
+import {
+  SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
+  SPL_NOOP_PROGRAM_ID,
+} from './generated';
+
+export const MPL_ACCOUNT_COMPRESSION_PROGRAM_ID =
+  'mcmt6YrQEMKw8Mw43FmpRLmf7BqRnFMKmAcbxE3xkAW' as PublicKey<'mcmt6YrQEMKw8Mw43FmpRLmf7BqRnFMKmAcbxE3xkAW'>;
+
+export const MPL_NOOP_PROGRAM_ID =
+  'mnoopTCrg4p8ry25e4bcWA9XZjbNjMTfgYVGGEdRsf3' as PublicKey<'mnoopTCrg4p8ry25e4bcWA9XZjbNjMTfgYVGGEdRsf3'>;
+
+// Constants for known genesis blockhashes on Solana.
+const SOLANA_MAINNET_GENESIS_HASH =
+  '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d';
+const SOLANA_DEVNET_GENESIS_HASH =
+  'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG';
+const SOLANA_TESTNET_GENESIS_HASH =
+  '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY';
+
+export type CompressionPrograms = {
+  logWrapper: PublicKey;
+  compressionProgram: PublicKey;
+};
+
+export async function getCompressionPrograms(
+  context: Pick<Context, 'programs' | 'eddsa' | 'rpc'>
+): Promise<CompressionPrograms> {
+  const genesisHash = await context.rpc.call<string>('getGenesisHash');
+
+  // Determine if the genesis hash matches known clusters.
+  const isSolanaCluster = [
+    SOLANA_MAINNET_GENESIS_HASH,
+    SOLANA_DEVNET_GENESIS_HASH,
+    SOLANA_TESTNET_GENESIS_HASH,
+  ].includes(genesisHash);
+
+  // Return appropriate program IDs based on the cluster.
+  if (isSolanaCluster) {
+    return {
+      logWrapper: SPL_NOOP_PROGRAM_ID,
+      compressionProgram: SPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
+    };
+  }
+  return {
+    logWrapper: MPL_NOOP_PROGRAM_ID,
+    compressionProgram: MPL_ACCOUNT_COMPRESSION_PROGRAM_ID,
+  };
+}

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -7,3 +7,4 @@ export * from './hooked';
 export * from './leafAssetId';
 export * from './merkle';
 export * from './plugin';
+export * from './getCompressionPrograms';


### PR DESCRIPTION
### Notes
* Also updated `createTree`.
* This isn't tested but a direct merge from svm branch where it is tested.
* Could not easily port the tests because they require a program change.
* I also didn't want to deploy this from the svm branch because that has additional error codes that are for the SVM-version of the program.