### PR TITLE
Use new mpl-core libs which result in name change to BubblegumV2 plugin

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -25,7 +25,7 @@
   "author": "Metaplex Maintainers <contact@metaplex.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@metaplex-foundation/digital-asset-standard-api": "1.1.0-beta.1",
+    "@metaplex-foundation/digital-asset-standard-api": "2.0.0",
     "@metaplex-foundation/mpl-account-compression": "0.0.1",
     "@metaplex-foundation/mpl-token-metadata": "3.2.1",
     "@metaplex-foundation/mpl-toolbox": "^0.10.0",
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
-    "@metaplex-foundation/mpl-core": "1.3.0-alpha.0",
+    "@metaplex-foundation/mpl-core": "1.4.0-beta.0",
     "@metaplex-foundation/umi": "^1.2.0",
     "@metaplex-foundation/umi-bundle-tests": "^1.0.0",
     "@metaplex-foundation/umi-rpc-web3js": "^1.2.0",

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@metaplex-foundation/digital-asset-standard-api':
-    specifier: 1.1.0-beta.1
-    version: 1.1.0-beta.1(@metaplex-foundation/umi@1.2.0)
+    specifier: 2.0.0
+    version: 2.0.0(@metaplex-foundation/umi@1.2.0)
   '@metaplex-foundation/mpl-account-compression':
     specifier: 0.0.1
     version: 0.0.1(@metaplex-foundation/umi@1.2.0)
@@ -32,8 +32,8 @@ devDependencies:
     specifier: ^3.0.1
     version: 3.0.1
   '@metaplex-foundation/mpl-core':
-    specifier: 1.3.0-alpha.0
-    version: 1.3.0-alpha.0(@metaplex-foundation/umi@1.2.0)(@noble/hashes@1.3.1)
+    specifier: 1.4.0-beta.0
+    version: 1.4.0-beta.0(@metaplex-foundation/umi@1.2.0)(@noble/hashes@1.3.1)
   '@metaplex-foundation/umi':
     specifier: ^1.2.0
     version: 1.2.0
@@ -290,8 +290,8 @@ packages:
       '@metaplex-foundation/umi': 1.2.0
     dev: false
 
-  /@metaplex-foundation/digital-asset-standard-api@1.1.0-beta.1(@metaplex-foundation/umi@1.2.0):
-    resolution: {integrity: sha512-srgyQ/GGFlWsfwd+4bLgWte2gnstumCXkPORHbO4wOQoiFyAD135X6aliIVOtgOvqoKvR277wDr/hKpqsl46vg==}
+  /@metaplex-foundation/digital-asset-standard-api@2.0.0(@metaplex-foundation/umi@1.2.0):
+    resolution: {integrity: sha512-CnFN7epCwNcei+OzDvIg7KpTcB+O827YKomdjKEl72LF/DHfDMXqpbnXf2qsIF4iGaBEOviwxkjUwbXIDLpAxQ==}
     peerDependencies:
       '@metaplex-foundation/umi': '>= 0.8.2 <= 1'
     dependencies:
@@ -309,8 +309,8 @@ packages:
       merkletreejs: 0.3.11
     dev: false
 
-  /@metaplex-foundation/mpl-core@1.3.0-alpha.0(@metaplex-foundation/umi@1.2.0)(@noble/hashes@1.3.1):
-    resolution: {integrity: sha512-cSBhDLBT5pTX4jzLPi7vX07oxWX4ke7H2mRPj6sYQm36C8l01kCEVxIoRCdVcDfK/JJZ13XzLw4E8cMviL/XkA==}
+  /@metaplex-foundation/mpl-core@1.4.0-beta.0(@metaplex-foundation/umi@1.2.0)(@noble/hashes@1.3.1):
+    resolution: {integrity: sha512-HVgvHyvf6tGYlTSrfvNNfeBJQSDwa6vGW53Z/Nyy5Qt4t0UdGslbNHUN0iGG8pn29h0KTNeW153dAjGm96oEBQ==}
     peerDependencies:
       '@metaplex-foundation/umi': '>=0.8.2 <= 1.0'
       '@noble/hashes': ^1.3.1

--- a/clients/js/src/generated/errors/mplBubblegum.ts
+++ b/clients/js/src/generated/errors/mplBubblegum.ts
@@ -699,7 +699,7 @@ export class CollectionIsFrozenError extends ProgramError {
 codeToErrorMap.set(0x17a0, CollectionIsFrozenError);
 nameToErrorMap.set('CollectionIsFrozen', CollectionIsFrozenError);
 
-/** CollectionMustHaveBubblegumPlugin: Core collections must have the Bubblegum V1 plugin on them */
+/** CollectionMustHaveBubblegumPlugin: Core collections must have the Bubblegum V2 plugin on them */
 export class CollectionMustHaveBubblegumPluginError extends ProgramError {
   readonly name: string = 'CollectionMustHaveBubblegumPlugin';
 
@@ -707,7 +707,7 @@ export class CollectionMustHaveBubblegumPluginError extends ProgramError {
 
   constructor(program: Program, cause?: Error) {
     super(
-      'Core collections must have the Bubblegum V1 plugin on them',
+      'Core collections must have the Bubblegum V2 plugin on them',
       program,
       cause
     );

--- a/clients/js/test/burnV2.test.ts
+++ b/clients/js/test/burnV2.test.ts
@@ -114,7 +114,7 @@ test('item set to non-transferrable can be burnt by owner', async (t) => {
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentFreezeDelegate',

--- a/clients/js/test/mintV2ToCollectionAndTransfer.test.ts
+++ b/clients/js/test/mintV2ToCollectionAndTransfer.test.ts
@@ -34,7 +34,7 @@ test('it can mint an NFT from a collection and then transfer it using V2 instruc
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
     ],
   }).sendAndConfirm(umi);

--- a/clients/js/test/permanentBurnDelegate.test.ts
+++ b/clients/js/test/permanentBurnDelegate.test.ts
@@ -45,7 +45,7 @@ test('permanent burn delegate on collection can burn a compressed NFT', async (t
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentBurnDelegate',
@@ -125,7 +125,7 @@ test('permanent burn delegate can burn a compressed NFT even if asset is frozen 
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentBurnDelegate',
@@ -233,7 +233,7 @@ test('permanent burn delegate can burn a compressed NFT even if asset is frozen 
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentBurnDelegate',
@@ -348,7 +348,7 @@ test('permanent burn delegate can burn a compressed NFT even if collection is fr
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentBurnDelegate',
@@ -443,7 +443,7 @@ test('item set to non-transferrable can be burnt by permanent burn delegate', as
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentBurnDelegate',

--- a/clients/js/test/permanentFreezeDelegate.test.ts
+++ b/clients/js/test/permanentFreezeDelegate.test.ts
@@ -41,7 +41,7 @@ test('permanent freeze delegate on collection can freeze a compressed NFT', asyn
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentFreezeDelegate',
@@ -130,7 +130,7 @@ test('permanent freeze delegate on collection can thaw compressed NFT it previou
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentFreezeDelegate',
@@ -246,7 +246,7 @@ test('asset cannot be transferred by owner when asset is frozen by permanent fre
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentFreezeDelegate',
@@ -359,7 +359,7 @@ test('asset cannot be transferred by owner when collection is frozen', async (t)
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentFreezeDelegate',
@@ -456,7 +456,7 @@ test('asset cannot be burned by owner when asset is frozen by permanent freeze d
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentFreezeDelegate',
@@ -567,7 +567,7 @@ test('asset cannot be burned by owner when collection is frozen', async (t) => {
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentFreezeDelegate',

--- a/clients/js/test/permanentTransferDelegate.test.ts
+++ b/clients/js/test/permanentTransferDelegate.test.ts
@@ -39,7 +39,7 @@ test('permanent transfer delegate on collection can transfer a compressed NFT', 
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentTransferDelegate',
@@ -127,7 +127,7 @@ test('permanent transfer delegate can transfer a compressed NFT even asset is fr
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentTransferDelegate',
@@ -244,7 +244,7 @@ test('permanent transfer delegate can transfer a compressed NFT even asset is fr
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentTransferDelegate',
@@ -368,7 +368,7 @@ test('permanent transfer delegate can transfer a compressed NFT even if collecti
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentTransferDelegate',
@@ -470,7 +470,7 @@ test('permanent transfer delegate can transfer a compressed NFT even if it would
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentTransferDelegate',

--- a/clients/js/test/royalties.test.ts
+++ b/clients/js/test/royalties.test.ts
@@ -35,7 +35,7 @@ test('A core collection with Royalties plugin can block a transfer of a compress
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'Royalties',
@@ -126,7 +126,7 @@ test('A core collection with Royalties plugin can block a transfer of a compress
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'Royalties',
@@ -217,7 +217,7 @@ test('A core collection with Royalties plugin can allow a transfer of a compress
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'Royalties',
@@ -311,7 +311,7 @@ test('A core collection with Royalties plugin can allow a transfer of a compress
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'Royalties',

--- a/clients/js/test/setCollectionV2.test.ts
+++ b/clients/js/test/setCollectionV2.test.ts
@@ -37,7 +37,7 @@ test('it can mint an NFT to a collection and then remove it from collection usin
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
     ],
   }).sendAndConfirm(umi);
@@ -146,7 +146,7 @@ test('it can mint an NFT not in a collection then add it to collection using V2 
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
     ],
   }).sendAndConfirm(umi);
@@ -199,7 +199,7 @@ test('it can mint an NFT to a collection and move it to a new collection using V
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
     ],
   }).sendAndConfirm(umi);
@@ -243,7 +243,7 @@ test('it can mint an NFT to a collection and move it to a new collection using V
     uri: 'https://example.com/collection2.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
     ],
   }).sendAndConfirm(umi);

--- a/clients/js/test/setNonTransferableV2.test.ts
+++ b/clients/js/test/setNonTransferableV2.test.ts
@@ -36,7 +36,7 @@ test('permanent freeze delegate on collection can set a compressed NFT to non-tr
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentFreezeDelegate',
@@ -123,7 +123,7 @@ test('owner as authority of Perm Freeze Delegate cannot set a compressed NFT to 
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentFreezeDelegate',
@@ -205,7 +205,7 @@ test('owner cannot set a compressed NFT to non-transferrable - no permanent free
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
     ],
   }).sendAndConfirm(umi);
@@ -281,7 +281,7 @@ test('asset set to non-transferrable cannot be transferred by owner', async (t) 
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentFreezeDelegate',
@@ -394,7 +394,7 @@ test('asset set to non-transferrable cannot be transferred by permanent transfer
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'PermanentTransferDelegate',

--- a/clients/js/test/updateMetadataV2.test.ts
+++ b/clients/js/test/updateMetadataV2.test.ts
@@ -200,7 +200,7 @@ test('it can update metadata using collection update authority if NFT is in a co
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
     ],
   }).sendAndConfirm(umi);
@@ -274,7 +274,7 @@ test('it can update metadata using collection update delegate when NFT is in a c
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'UpdateDelegate',
@@ -356,7 +356,7 @@ test('it can update metadata using collection update delegate additional delegat
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
       {
         type: 'UpdateDelegate',
@@ -447,7 +447,7 @@ test('it can update metadata using the getAssetWithProof helper with collection'
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
     ],
   }).sendAndConfirm(umi);
@@ -553,7 +553,7 @@ test('it cannot update metadata using tree owner when NFT is in collection', asy
     uri: 'https://example.com/collection.json',
     plugins: [
       {
-        type: 'BubblegumV1',
+        type: 'BubblegumV2',
       },
     ],
   }).sendAndConfirm(umi);

--- a/clients/rust/src/generated/errors/mpl_bubblegum.rs
+++ b/clients/rust/src/generated/errors/mpl_bubblegum.rs
@@ -157,8 +157,8 @@ pub enum MplBubblegumError {
     /// 6048 (0x17A0) - Collection is frozen
     #[error("Collection is frozen")]
     CollectionIsFrozen,
-    /// 6049 (0x17A1) - Core collections must have the Bubblegum V1 plugin on them
-    #[error("Core collections must have the Bubblegum V1 plugin on them")]
+    /// 6049 (0x17A1) - Core collections must have the Bubblegum V2 plugin on them
+    #[error("Core collections must have the Bubblegum V2 plugin on them")]
     CollectionMustHaveBubblegumPlugin,
     /// 6050 (0x17A2) - Feature not currently available
     #[error("Feature not currently available")]

--- a/idls/bubblegum.json
+++ b/idls/bubblegum.json
@@ -1198,8 +1198,8 @@
         "flag.  In `MetadataV2`, any collection included is automatically considered verified.",
         "3. Allows for use of plugins such as Royalties, Permanent Burn Delegate, etc. on the",
         "MPL Core collection to authorize operations on the Bubblegum asset.  Note the",
-        "`BubblegumV1` plugin must also be present on the MPL Core collection for it to be",
-        "used for Bubblegum.  See MPL Core `BubblegumV1` plugin for list of compatible",
+        "`BubblegumV2` plugin must also be present on the MPL Core collection for it to be",
+        "used for Bubblegum.  See MPL Core `BubblegumV2` plugin for list of compatible",
         "collection-level plugins.",
         "4. Allows for freezing/thawing of the asset, as well as setting an asset to be",
         "permanently non-transferable (soulbound).  Non-transferable is similar to freezing",
@@ -4329,7 +4329,7 @@
     {
       "code": 6049,
       "name": "CollectionMustHaveBubblegumPlugin",
-      "msg": "Core collections must have the Bubblegum V1 plugin on them"
+      "msg": "Core collections must have the Bubblegum V2 plugin on them"
     },
     {
       "code": 6050,

--- a/programs/bubblegum/Cargo.lock
+++ b/programs/bubblegum/Cargo.lock
@@ -2446,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-core"
-version = "0.10.0-alpha.1"
+version = "0.10.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cfff748ce1b56c96e94634bc122ca91febd8270210c5648195d2347403141d"
+checksum = "425afa1a767985204df79cee835d3a69eebccfe01786f5e9de056e2b1b1839f5"
 dependencies = [
  "base64 0.22.1",
  "borsh 0.10.3",

--- a/programs/bubblegum/program/Cargo.toml
+++ b/programs/bubblegum/program/Cargo.toml
@@ -25,7 +25,7 @@ anchor-spl = "0.29.0"
 bytemuck = "1.13.0"
 modular-bitfield = "0.11.2"
 mpl-account-compression = { version = "0.4.2", features = ["cpi"] }
-mpl-core = "0.10.0-alpha.1"
+mpl-core = "0.10.0-beta.1"
 mpl-noop = { version = "0.2.1", features = ["no-entrypoint"] }
 mpl-token-metadata = "4.1.2"
 num-traits = "0.2.15"

--- a/programs/bubblegum/program/src/error.rs
+++ b/programs/bubblegum/program/src/error.rs
@@ -102,7 +102,7 @@ pub enum BubblegumError {
     InvalidAuthority,
     #[msg("Collection is frozen")]
     CollectionIsFrozen,
-    #[msg("Core collections must have the Bubblegum V1 plugin on them")]
+    #[msg("Core collections must have the Bubblegum V2 plugin on them")]
     CollectionMustHaveBubblegumPlugin,
     #[msg("Feature not currently available")]
     NotAvailable,

--- a/programs/bubblegum/program/src/lib.rs
+++ b/programs/bubblegum/program/src/lib.rs
@@ -294,8 +294,8 @@ pub mod bubblegum {
     ///      flag.  In `MetadataV2`, any collection included is automatically considered verified.
     ///   3. Allows for use of plugins such as Royalties, Permanent Burn Delegate, etc. on the
     ///      MPL Core collection to authorize operations on the Bubblegum asset.  Note the
-    ///      `BubblegumV1` plugin must also be present on the MPL Core collection for it to be
-    ///      used for Bubblegum.  See MPL Core `BubblegumV1` plugin for list of compatible
+    ///      `BubblegumV2` plugin must also be present on the MPL Core collection for it to be
+    ///      used for Bubblegum.  See MPL Core `BubblegumV2` plugin for list of compatible
     ///      collection-level plugins.
     ///   4. Allows for freezing/thawing of the asset, as well as setting an asset to be
     ///      permanently non-transferable (soulbound).  Non-transferable is similar to freezing

--- a/programs/bubblegum/program/src/processor/mod.rs
+++ b/programs/bubblegum/program/src/processor/mod.rs
@@ -396,8 +396,8 @@ fn process_collection_verification_mpl_core_only<'info>(
         return Err(BubblegumError::InvalidCollectionAuthority.into());
     }
 
-    // Make sure the collection has the `BubblegumV1` plugin.
-    if collection.plugin_list.bubblegum_v1.is_none() {
+    // Make sure the collection has the `BubblegumV2` plugin.
+    if collection.plugin_list.bubblegum_v2.is_none() {
         return Err(BubblegumError::CollectionMustHaveBubblegumPlugin.into());
     }
 


### PR DESCRIPTION
### Notes
* Updated
  * @metaplex-foundation/digital-asset-standard-api npm package
  * @metaplex-foundation/mpl-core npm package
  * and mpl-core crate in the program.
* FYI as expected, still works with the devnet version of mpl-core which is downloaded for the JS tests.