### PR TITLE
Fix thawAndRevokeV2

### DIFF
--- a/clients/js/src/generated/errors/mplBubblegum.ts
+++ b/clients/js/src/generated/errors/mplBubblegum.ts
@@ -800,6 +800,19 @@ nameToErrorMap.set(
   MissingMplCoreCpiSignerAccountError
 );
 
+/** AssetIsNotFrozen: Asset is not frozen */
+export class AssetIsNotFrozenError extends ProgramError {
+  readonly name: string = 'AssetIsNotFrozen';
+
+  readonly code: number = 0x17a8; // 6056
+
+  constructor(program: Program, cause?: Error) {
+    super('Asset is not frozen', program, cause);
+  }
+}
+codeToErrorMap.set(0x17a8, AssetIsNotFrozenError);
+nameToErrorMap.set('AssetIsNotFrozen', AssetIsNotFrozenError);
+
 /**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors

--- a/clients/js/src/generated/instructions/setCollectionV2.ts
+++ b/clients/js/src/generated/instructions/setCollectionV2.ts
@@ -212,11 +212,9 @@ export function setCollectionV2(
     resolvedAccounts.payer.value = context.payer;
   }
   if (!resolvedAccounts.mplCoreCpiSigner.value) {
-    if (resolvedAccounts.coreCollection.value) {
-      resolvedAccounts.mplCoreCpiSigner.value = publicKey(
-        'CbNY3JiXdXNE9tPNEk1aRZVEkWdj2v7kfJLNQwZZgpXk'
-      );
-    }
+    resolvedAccounts.mplCoreCpiSigner.value = publicKey(
+      'CbNY3JiXdXNE9tPNEk1aRZVEkWdj2v7kfJLNQwZZgpXk'
+    );
   }
   if (!resolvedAccounts.logWrapper.value) {
     resolvedAccounts.logWrapper.value = context.programs.getPublicKey(

--- a/clients/js/test/delegateAndFreezeV2.test.ts
+++ b/clients/js/test/delegateAndFreezeV2.test.ts
@@ -106,15 +106,6 @@ test('owner cannot thaw a compressed NFT that was frozen using delegateAndFreeze
   await t.throwsAsync(promise, { name: 'InvalidAuthority' });
 
   // And the leaf was not updated in the merkle tree.
-  const stillFrozenLeaf = hashLeafV2(umi, {
-    merkleTree,
-    owner: leafOwner.publicKey,
-    delegate: newDelegate.publicKey,
-    leafIndex,
-    metadata,
-    flags: 1,
-  });
   merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
-  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(stillFrozenLeaf));
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(frozenLeaf));
 });
-

--- a/clients/js/test/freezeV2.test.ts
+++ b/clients/js/test/freezeV2.test.ts
@@ -1,7 +1,4 @@
-import {
-  generateSigner,
-  publicKey,
-} from '@metaplex-foundation/umi';
+import { generateSigner, publicKey } from '@metaplex-foundation/umi';
 import test from 'ava';
 import {
   fetchMerkleTree,

--- a/clients/js/test/thawV2.test.ts
+++ b/clients/js/test/thawV2.test.ts
@@ -199,16 +199,8 @@ test('owner cannot thaw a compressed NFT using V2 instructions', async (t) => {
   await t.throwsAsync(promise, { name: 'InvalidAuthority' });
 
   // And the leaf was not updated in the merkle tree.
-  const stillFrozenLeaf = hashLeafV2(umi, {
-    merkleTree,
-    owner: leafOwner.publicKey,
-    delegate: newDelegate.publicKey,
-    leafIndex,
-    metadata,
-    flags: 1,
-  });
   merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
-  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(stillFrozenLeaf));
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(frozenLeaf));
 });
 
 test('owner as default leaf delegate can thaw a compressed NFT it previously froze', async (t) => {

--- a/clients/js/test/updateMetadataV2.test.ts
+++ b/clients/js/test/updateMetadataV2.test.ts
@@ -641,14 +641,14 @@ test('it cannot update immutable metadata using V2 instructions', async (t) => {
     ...metadata,
     isMutable: false,
   };
-  const updatedLeaf = hashLeafV2(umi, {
+  const leaf = hashLeafV2(umi, {
     merkleTree,
     owner: leafOwner,
     leafIndex: 0,
     metadata: immutableMetadata,
   });
   merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
-  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(updatedLeaf));
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(leaf));
 
   // Then we attempt to update metadata.
   const updateArgs: UpdateArgsArgs = {
@@ -670,14 +670,8 @@ test('it cannot update immutable metadata using V2 instructions', async (t) => {
   await t.throwsAsync(promise, { name: 'MetadataImmutable' });
 
   // And the leaf was not updated in the merkle tree.
-  const notUpdatedLeaf = hashLeafV2(umi, {
-    merkleTree,
-    owner: leafOwner,
-    leafIndex,
-    metadata: immutableMetadata,
-  });
   merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
-  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(notUpdatedLeaf));
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(leaf));
 });
 
 test('it cannot verify currently unverified creator if not signer using V2 instructions', async (t) => {

--- a/clients/rust/src/generated/errors/mpl_bubblegum.rs
+++ b/clients/rust/src/generated/errors/mpl_bubblegum.rs
@@ -178,6 +178,9 @@ pub enum MplBubblegumError {
     /// 6055 (0x17A7) - Missing mpl-core CPI signer account
     #[error("Missing mpl-core CPI signer account")]
     MissingMplCoreCpiSignerAccount,
+    /// 6056 (0x17A8) - Asset is not frozen
+    #[error("Asset is not frozen")]
+    AssetIsNotFrozen,
 }
 
 impl solana_program::program_error::PrintProgramError for MplBubblegumError {

--- a/clients/rust/src/generated/instructions/burn_v2.rs
+++ b/clients/rust/src/generated/instructions/burn_v2.rs
@@ -23,7 +23,7 @@ pub struct BurnV2 {
 
     pub core_collection: Option<solana_program::pubkey::Pubkey>,
 
-    pub mpl_core_cpi_signer: solana_program::pubkey::Pubkey,
+    pub mpl_core_cpi_signer: Option<solana_program::pubkey::Pubkey>,
 
     pub log_wrapper: solana_program::pubkey::Pubkey,
 
@@ -86,10 +86,17 @@ impl BurnV2 {
                 false,
             ));
         }
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.mpl_core_cpi_signer,
-            false,
-        ));
+        if let Some(mpl_core_cpi_signer) = self.mpl_core_cpi_signer {
+            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+                mpl_core_cpi_signer,
+                false,
+            ));
+        } else {
+            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+                crate::MPL_BUBBLEGUM_ID,
+                false,
+            ));
+        }
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.log_wrapper,
             false,
@@ -213,12 +220,13 @@ impl BurnV2Builder {
         self.core_collection = core_collection;
         self
     }
+    /// `[optional account]`
     #[inline(always)]
     pub fn mpl_core_cpi_signer(
         &mut self,
-        mpl_core_cpi_signer: solana_program::pubkey::Pubkey,
+        mpl_core_cpi_signer: Option<solana_program::pubkey::Pubkey>,
     ) -> &mut Self {
-        self.mpl_core_cpi_signer = Some(mpl_core_cpi_signer);
+        self.mpl_core_cpi_signer = mpl_core_cpi_signer;
         self
     }
     /// `[optional account, default to 'mnoopTCrg4p8ry25e4bcWA9XZjbNjMTfgYVGGEdRsf3']`
@@ -315,9 +323,7 @@ impl BurnV2Builder {
             leaf_delegate: self.leaf_delegate,
             merkle_tree: self.merkle_tree.expect("merkle_tree is not set"),
             core_collection: self.core_collection,
-            mpl_core_cpi_signer: self
-                .mpl_core_cpi_signer
-                .expect("mpl_core_cpi_signer is not set"),
+            mpl_core_cpi_signer: self.mpl_core_cpi_signer,
             log_wrapper: self.log_wrapper.unwrap_or(solana_program::pubkey!(
                 "mnoopTCrg4p8ry25e4bcWA9XZjbNjMTfgYVGGEdRsf3"
             )),
@@ -360,7 +366,7 @@ pub struct BurnV2CpiAccounts<'a, 'b> {
 
     pub core_collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 
-    pub mpl_core_cpi_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub mpl_core_cpi_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 
     pub log_wrapper: &'b solana_program::account_info::AccountInfo<'a>,
 
@@ -389,7 +395,7 @@ pub struct BurnV2Cpi<'a, 'b> {
 
     pub core_collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 
-    pub mpl_core_cpi_signer: &'b solana_program::account_info::AccountInfo<'a>,
+    pub mpl_core_cpi_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 
     pub log_wrapper: &'b solana_program::account_info::AccountInfo<'a>,
 
@@ -496,10 +502,17 @@ impl<'a, 'b> BurnV2Cpi<'a, 'b> {
                 false,
             ));
         }
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.mpl_core_cpi_signer.key,
-            false,
-        ));
+        if let Some(mpl_core_cpi_signer) = self.mpl_core_cpi_signer {
+            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+                *mpl_core_cpi_signer.key,
+                false,
+            ));
+        } else {
+            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+                crate::MPL_BUBBLEGUM_ID,
+                false,
+            ));
+        }
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             *self.log_wrapper.key,
             false,
@@ -544,7 +557,9 @@ impl<'a, 'b> BurnV2Cpi<'a, 'b> {
         if let Some(core_collection) = self.core_collection {
             account_infos.push(core_collection.clone());
         }
-        account_infos.push(self.mpl_core_cpi_signer.clone());
+        if let Some(mpl_core_cpi_signer) = self.mpl_core_cpi_signer {
+            account_infos.push(mpl_core_cpi_signer.clone());
+        }
         account_infos.push(self.log_wrapper.clone());
         account_infos.push(self.compression_program.clone());
         account_infos.push(self.mpl_core_program.clone());
@@ -645,12 +660,13 @@ impl<'a, 'b> BurnV2CpiBuilder<'a, 'b> {
         self.instruction.core_collection = core_collection;
         self
     }
+    /// `[optional account]`
     #[inline(always)]
     pub fn mpl_core_cpi_signer(
         &mut self,
-        mpl_core_cpi_signer: &'b solana_program::account_info::AccountInfo<'a>,
+        mpl_core_cpi_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
-        self.instruction.mpl_core_cpi_signer = Some(mpl_core_cpi_signer);
+        self.instruction.mpl_core_cpi_signer = mpl_core_cpi_signer;
         self
     }
     #[inline(always)]
@@ -801,10 +817,7 @@ impl<'a, 'b> BurnV2CpiBuilder<'a, 'b> {
 
             core_collection: self.instruction.core_collection,
 
-            mpl_core_cpi_signer: self
-                .instruction
-                .mpl_core_cpi_signer
-                .expect("mpl_core_cpi_signer is not set"),
+            mpl_core_cpi_signer: self.instruction.mpl_core_cpi_signer,
 
             log_wrapper: self
                 .instruction

--- a/clients/rust/src/generated/instructions/set_collection_v2.rs
+++ b/clients/rust/src/generated/instructions/set_collection_v2.rs
@@ -281,6 +281,7 @@ impl SetCollectionV2Builder {
         self.new_core_collection = new_core_collection;
         self
     }
+    /// `[optional account, default to 'CbNY3JiXdXNE9tPNEk1aRZVEkWdj2v7kfJLNQwZZgpXk']`
     #[inline(always)]
     pub fn mpl_core_cpi_signer(
         &mut self,
@@ -381,9 +382,9 @@ impl SetCollectionV2Builder {
             merkle_tree: self.merkle_tree.expect("merkle_tree is not set"),
             core_collection: self.core_collection,
             new_core_collection: self.new_core_collection,
-            mpl_core_cpi_signer: self
-                .mpl_core_cpi_signer
-                .expect("mpl_core_cpi_signer is not set"),
+            mpl_core_cpi_signer: self.mpl_core_cpi_signer.unwrap_or(solana_program::pubkey!(
+                "CbNY3JiXdXNE9tPNEk1aRZVEkWdj2v7kfJLNQwZZgpXk"
+            )),
             log_wrapper: self.log_wrapper.unwrap_or(solana_program::pubkey!(
                 "mnoopTCrg4p8ry25e4bcWA9XZjbNjMTfgYVGGEdRsf3"
             )),

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -146,6 +146,8 @@ kinobi.update(
   ])
 );
 
+// The CPI call to Token Metadata has been deprecated in these
+// V1 insructions.
 const deprecatedTmIxes = [
   "mintToCollectionV1",
   "setAndVerifyCollection",
@@ -163,6 +165,8 @@ for (let ix of deprecatedTmIxes) {
     })
 }
 
+// Use spl-noop and spl-account-compression as defaults for all
+// V2 instructions.
 const v1Ixs = [
   "burn",
   "cancel_redeem",
@@ -205,6 +209,8 @@ for (let ix of v1Ixs) {
     })
 }
 
+// Use mpl-noop and mpl-account-compression as defaults for all
+// V2 instructions.
 const v2Ixs = [
   "burnV2",
   "createTreeV2",
@@ -246,6 +252,8 @@ for (let ix of v2Ixs) {
     })
 }
 
+// We skip defaulting leaf delegate only for `freezeV2` and `thawV2` where
+// we want the delegate to be made explicit by the caller.
 const allLeafDelegateIxs = [...v1Ixs, ...v2Ixs];
 const skipLeafDelegateDefaultFor = new Set([
   "freezeV2",
@@ -331,6 +339,13 @@ kinobi.update(
       ...k.conditionalDefault("account", "coreCollection", {
         ifTrue: k.publicKeyDefault("CbNY3JiXdXNE9tPNEk1aRZVEkWdj2v7kfJLNQwZZgpXk"),
       }),
+    },
+    // `setCollectionV2` always requires the MPL Core signer so it's not a conditional
+    // default based on `coreCollection`.
+    {
+      account: "mplCoreCpiSigner",
+      instruction: "setCollectionV2",
+      ...k.publicKeyDefault("CbNY3JiXdXNE9tPNEk1aRZVEkWdj2v7kfJLNQwZZgpXk"),
     },
     ...deprecatedIxUpdaters,
     ...v1IxUpdaters,

--- a/idls/bubblegum.json
+++ b/idls/bubblegum.json
@@ -4360,6 +4360,11 @@
       "code": 6055,
       "name": "MissingMplCoreCpiSignerAccount",
       "msg": "Missing mpl-core CPI signer account"
+    },
+    {
+      "code": 6056,
+      "name": "AssetIsNotFrozen",
+      "msg": "Asset is not frozen"
     }
   ],
   "metadata": {

--- a/idls/bubblegum.json
+++ b/idls/bubblegum.json
@@ -130,7 +130,8 @@
         {
           "name": "mplCoreCpiSigner",
           "isMut": false,
-          "isSigner": false
+          "isSigner": false,
+          "isOptional": true
         },
         {
           "name": "logWrapper",

--- a/programs/bubblegum/program/src/error.rs
+++ b/programs/bubblegum/program/src/error.rs
@@ -116,6 +116,8 @@ pub enum BubblegumError {
     AlreadyNotInCollection,
     #[msg("Missing mpl-core CPI signer account")]
     MissingMplCoreCpiSignerAccount,
+    #[msg("Asset is not frozen")]
+    AssetIsNotFrozen,
 }
 
 // Converts certain Token Metadata errors into Bubblegum equivalents

--- a/programs/bubblegum/program/src/processor/delegate.rs
+++ b/programs/bubblegum/program/src/processor/delegate.rs
@@ -134,7 +134,8 @@ pub(crate) fn delegate_v2<'info>(
     );
 
     // Ensure asset is not frozen.
-    let flags = flags.unwrap_or(DEFAULT_FLAGS);
+    let raw_flags = flags.unwrap_or(DEFAULT_FLAGS);
+    let flags = Flags::from_bytes([raw_flags]);
     asset_validate_delegate(flags)?;
 
     // Gather info for previous leaf and new leaf.
@@ -166,7 +167,7 @@ pub(crate) fn delegate_v2<'info>(
         creator_hash,
         collection_hash,
         asset_data_hash,
-        flags,
+        raw_flags,
     );
 
     let new_leaf = LeafSchema::new_v2(
@@ -178,7 +179,7 @@ pub(crate) fn delegate_v2<'info>(
         creator_hash,
         collection_hash,
         asset_data_hash,
-        flags,
+        raw_flags,
     );
 
     crate::utils::wrap_application_data_v1(
@@ -203,9 +204,7 @@ pub(crate) fn delegate_v2<'info>(
     )
 }
 
-pub(crate) fn asset_validate_delegate(flags: u8) -> Result<()> {
-    let flags = Flags::from_bytes([flags]);
-
+pub(crate) fn asset_validate_delegate(flags: Flags) -> Result<()> {
     if flags.asset_lvl_frozen() || flags.permanent_lvl_frozen() {
         return Err(BubblegumError::AssetIsFrozen.into());
     }

--- a/programs/bubblegum/program/src/processor/delegate_and_freeze.rs
+++ b/programs/bubblegum/program/src/processor/delegate_and_freeze.rs
@@ -10,7 +10,8 @@ use crate::{
         TreeConfig,
     },
     utils::{
-        get_asset_id, replace_leaf, DEFAULT_ASSET_DATA_HASH, DEFAULT_COLLECTION_HASH, DEFAULT_FLAGS,
+        get_asset_id, replace_leaf, Flags, DEFAULT_ASSET_DATA_HASH, DEFAULT_COLLECTION_HASH,
+        DEFAULT_FLAGS,
     },
 };
 
@@ -56,11 +57,12 @@ pub(crate) fn delegate_and_freeze_v2<'info>(
     );
 
     // Ensure asset is not frozen.
-    let flags = flags.unwrap_or(DEFAULT_FLAGS);
+    let raw_flags = flags.unwrap_or(DEFAULT_FLAGS);
+    let flags = Flags::from_bytes([raw_flags]);
     asset_validate_delegate(flags)?;
 
     // Set freeze flag.
-    let updated_flags = set_asset_lvl_freeze_flag(flags, true);
+    let updated_flags = set_asset_lvl_freeze_flag(raw_flags, true);
 
     // Gather info for previous leaf and new leaf.
     let merkle_tree = &ctx.accounts.merkle_tree;
@@ -92,7 +94,7 @@ pub(crate) fn delegate_and_freeze_v2<'info>(
         creator_hash,
         collection_hash,
         asset_data_hash,
-        flags,
+        raw_flags,
     );
 
     // Set new leaf delegate, and use updated flags.


### PR DESCRIPTION
* Don't allow `thawAndRevokeV2` to be called on an asset frozen at the asset-level.
* Make mpl-core CPI signer optional for `BurnV2`.
* Add default mpl-core CPI signer for `setCollectionV2` (not based on `coreCollection` being present like for all other instructions).
* Clean up some JS tests.
* Make flags validation functions more consistent in program code.