### PR TITLE
Add leaf parser for mintV2

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -34,7 +34,7 @@
     "merkletreejs": "^0.3.11"
   },
   "peerDependencies": {
-    "@metaplex-foundation/umi": ">= 0.8.9 <= 1"
+    "@metaplex-foundation/umi": ">= 0.8.9 <= 2.0.0"
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",

--- a/clients/js/test/parseMintV2.test.ts
+++ b/clients/js/test/parseMintV2.test.ts
@@ -1,0 +1,109 @@
+/* eslint-disable no-await-in-loop */
+import { createCollection } from '@metaplex-foundation/mpl-core';
+import {
+  defaultPublicKey,
+  generateSigner,
+  some,
+  none,
+} from '@metaplex-foundation/umi';
+import test from 'ava';
+import { fetchMerkleTree } from '@metaplex-foundation/spl-account-compression';
+import {
+  MetadataArgsV2Args,
+  findLeafAssetIdPda,
+  mintV2,
+  parseLeafFromMintV2Transaction,
+} from '../src';
+import { createTreeV2, createUmi } from './_setup';
+
+test('it can parse the leaf from mintV2 instructions', async (t) => {
+  // Given an empty Bubblegum tree.
+  const umi = await createUmi();
+  const merkleTree = await createTreeV2(umi);
+  const leafOwner = generateSigner(umi).publicKey;
+  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.sequenceNumber, 0n);
+  t.is(merkleTreeAccount.tree.activeIndex, 0n);
+  t.is(merkleTreeAccount.tree.bufferSize, 1n);
+  t.is(merkleTreeAccount.tree.rightMostPath.index, 0);
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, defaultPublicKey());
+
+  // When we mint a new NFT from the tree using the following metadata.
+  const metadata: MetadataArgsV2Args = {
+    name: 'My NFT',
+    uri: 'https://example.com/my-nft.json',
+    sellerFeeBasisPoints: 500, // 5%
+    collection: none(),
+    creators: [],
+  };
+
+  // Test with 10 different leaves to be sure they increment correctly.
+  for (let nonce = 0; nonce < 10; nonce += 1) {
+    const { signature } = await mintV2(umi, {
+      leafOwner,
+      merkleTree,
+      metadata,
+    }).sendAndConfirm(umi, { confirm: { commitment: 'confirmed' } });
+    const leaf = await parseLeafFromMintV2Transaction(umi, signature);
+    const assetId = findLeafAssetIdPda(umi, { merkleTree, leafIndex: nonce });
+
+    t.is(leafOwner, leaf.owner);
+    t.is(Number(leaf.nonce), nonce);
+    t.is(leaf.id, assetId[0]);
+  }
+});
+
+test('it can parse the leaf from mintV2 to collection instructions)', async (t) => {
+  // Given an empty Bubblegum tree.
+  const umi = await createUmi();
+  const merkleTree = await createTreeV2(umi);
+  const leafOwner = generateSigner(umi).publicKey;
+  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.sequenceNumber, 0n);
+  t.is(merkleTreeAccount.tree.activeIndex, 0n);
+  t.is(merkleTreeAccount.tree.bufferSize, 1n);
+  t.is(merkleTreeAccount.tree.rightMostPath.index, 0);
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, defaultPublicKey());
+
+  // And a Collection NFT.
+  const coreCollection = generateSigner(umi);
+  const collectionUpdateAuthority = generateSigner(umi);
+  await createCollection(umi, {
+    collection: coreCollection,
+    updateAuthority: collectionUpdateAuthority.publicKey,
+    name: 'Test Collection',
+    uri: 'https://example.com/collection.json',
+    plugins: [
+      {
+        type: 'BubblegumV2',
+      },
+    ],
+  }).sendAndConfirm(umi);
+
+  // When we mint a new NFT from the tree using the following metadata.
+  const metadata: MetadataArgsV2Args = {
+    name: 'My NFT',
+    uri: 'https://example.com/my-nft.json',
+    sellerFeeBasisPoints: 550, // 5.5%
+    collection: some(coreCollection.publicKey),
+    creators: [],
+  };
+
+  // Test with 10 different leaves to be sure they increment correctly.
+  for (let nonce = 0; nonce < 10; nonce += 1) {
+    const { signature } = await mintV2(umi, {
+      collectionAuthority: collectionUpdateAuthority,
+      leafOwner,
+      merkleTree,
+      coreCollection: coreCollection.publicKey,
+      metadata,
+    }).sendAndConfirm(umi);
+
+    const leaf = await parseLeafFromMintV2Transaction(umi, signature);
+    const assetId = findLeafAssetIdPda(umi, { merkleTree, leafIndex: nonce });
+
+    t.is(leafOwner, leaf.owner);
+    t.is(Number(leaf.nonce), nonce);
+    t.is(leaf.id, assetId[0]);
+  }
+});

--- a/programs/bubblegum/program/src/processor/mint.rs
+++ b/programs/bubblegum/program/src/processor/mint.rs
@@ -302,6 +302,8 @@ pub(crate) fn process_mint<'info, T: MetadataArgsCommon>(
     );
 
     let asset_id = get_asset_id(&merkle_tree.key(), tree_authority.num_minted);
+    solana_program::msg!("Leaf asset ID: {}", asset_id);
+
     let leaf_delegate = leaf_delegate.unwrap_or(leaf_owner);
     let version = message.version();
     let leaf = match version {


### PR DESCRIPTION
* Added parser for mintV2.  Had to add some logic because the noop is not always the same inner instruction, depending on if there's a CPI into mpl-core for collection bookkeeping first.
* Also just log asset ID in the program log for random convenience.  Not sure why that was never done before.