### PR TITLE
Fixing Payer not being mut in MintV2

### DIFF
--- a/clients/js/src/generated/instructions/mintV2.ts
+++ b/clients/js/src/generated/instructions/mintV2.ts
@@ -119,7 +119,7 @@ export function mintV2(
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
     treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     treeCreatorOrDelegate: {
       index: 2,
       isWritable: false,

--- a/clients/js/test/mintV2_only.test.ts
+++ b/clients/js/test/mintV2_only.test.ts
@@ -2,6 +2,7 @@ import {
   defaultPublicKey,
   generateSigner,
   publicKey,
+  sol,
 } from '@metaplex-foundation/umi';
 import test from 'ava';
 
@@ -18,6 +19,32 @@ test('it can mint a compressed NFT using V2 instructions', async (t) => {
   const { metadata, leafIndex } = await mintV2(umi, {
     merkleTree,
     leafOwner: leafOwnerA.publicKey,
+  });
+
+  // Then the leaf is in the merkle tree.
+  const leaf = hashLeafV2(umi, {
+    merkleTree,
+    owner: leafOwnerA.publicKey,
+    leafIndex,
+    metadata,
+  });
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(leaf));
+});
+
+test('it can mint a compressed NFT with a separate payer', async (t) => {
+  // Given a tree with a minted NFT owned by leafOwnerA.
+  const umi = await createUmi();
+  const merkleTree = await createTreeV2(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  const leafOwnerA = generateSigner(umi);
+  const payer = generateSigner(umi);
+  await umi.rpc.airdrop(payer.publicKey, sol(1));
+  const { metadata, leafIndex } = await mintV2(umi, {
+    merkleTree,
+    leafOwner: leafOwnerA.publicKey,
+    payer,
+    treeCreatorOrDelegate: umi.identity,
   });
 
   // Then the leaf is in the merkle tree.

--- a/clients/rust/src/generated/instructions/mint_v2.rs
+++ b/clients/rust/src/generated/instructions/mint_v2.rs
@@ -57,7 +57,7 @@ impl MintV2 {
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(tree_creator_or_delegate) = self.tree_creator_or_delegate {
@@ -491,7 +491,7 @@ impl<'a, 'b> MintV2Cpi<'a, 'b> {
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));

--- a/idls/bubblegum.json
+++ b/idls/bubblegum.json
@@ -1216,7 +1216,7 @@
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {

--- a/programs/bubblegum/program/src/processor/mint.rs
+++ b/programs/bubblegum/program/src/processor/mint.rs
@@ -108,6 +108,7 @@ pub struct MintV2<'info> {
         bump,
     )]
     pub tree_authority: Account<'info, TreeConfig>,
+    #[account(mut)]
     pub payer: Signer<'info>,
     /// Optional tree delegate, defaults to `payer`
     pub tree_delegate: Option<Signer<'info>>,


### PR DESCRIPTION
The payer was not marked as mutable in MintV2 struct so the clients being generated do not pass in the account as writable.