### PR TITLE
Make payer accounts mutable in V2 instructions and add tests

### DIFF
--- a/clients/js/src/generated/instructions/delegateAndFreezeV2.ts
+++ b/clients/js/src/generated/instructions/delegateAndFreezeV2.ts
@@ -135,12 +135,8 @@ export function delegateAndFreezeV2(
 
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
-    treeConfig: {
-      index: 0,
-      isWritable: false,
-      value: input.treeConfig ?? null,
-    },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     leafOwner: { index: 2, isWritable: false, value: input.leafOwner ?? null },
     previousLeafDelegate: {
       index: 3,

--- a/clients/js/src/generated/instructions/delegateV2.ts
+++ b/clients/js/src/generated/instructions/delegateV2.ts
@@ -128,12 +128,8 @@ export function delegateV2(
 
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
-    treeConfig: {
-      index: 0,
-      isWritable: false,
-      value: input.treeConfig ?? null,
-    },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     leafOwner: { index: 2, isWritable: false, value: input.leafOwner ?? null },
     previousLeafDelegate: {
       index: 3,

--- a/clients/js/src/generated/instructions/freezeV2.ts
+++ b/clients/js/src/generated/instructions/freezeV2.ts
@@ -129,12 +129,8 @@ export function freezeV2(
 
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
-    treeConfig: {
-      index: 0,
-      isWritable: false,
-      value: input.treeConfig ?? null,
-    },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     authority: { index: 2, isWritable: false, value: input.authority ?? null },
     leafOwner: { index: 3, isWritable: false, value: input.leafOwner ?? null },
     leafDelegate: {

--- a/clients/js/src/generated/instructions/setCollectionV2.ts
+++ b/clients/js/src/generated/instructions/setCollectionV2.ts
@@ -143,12 +143,8 @@ export function setCollectionV2(
 
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
-    treeConfig: {
-      index: 0,
-      isWritable: false,
-      value: input.treeConfig ?? null,
-    },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     authority: { index: 2, isWritable: false, value: input.authority ?? null },
     newCollectionAuthority: {
       index: 3,

--- a/clients/js/src/generated/instructions/setNonTransferableV2.ts
+++ b/clients/js/src/generated/instructions/setNonTransferableV2.ts
@@ -137,12 +137,8 @@ export function setNonTransferableV2(
 
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
-    treeConfig: {
-      index: 0,
-      isWritable: false,
-      value: input.treeConfig ?? null,
-    },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     authority: { index: 2, isWritable: false, value: input.authority ?? null },
     leafOwner: { index: 3, isWritable: false, value: input.leafOwner ?? null },
     leafDelegate: {

--- a/clients/js/src/generated/instructions/thawAndRevokeV2.ts
+++ b/clients/js/src/generated/instructions/thawAndRevokeV2.ts
@@ -129,12 +129,8 @@ export function thawAndRevokeV2(
 
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
-    treeConfig: {
-      index: 0,
-      isWritable: false,
-      value: input.treeConfig ?? null,
-    },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     leafDelegate: {
       index: 2,
       isWritable: false,

--- a/clients/js/src/generated/instructions/thawV2.ts
+++ b/clients/js/src/generated/instructions/thawV2.ts
@@ -125,12 +125,8 @@ export function thawV2(
 
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
-    treeConfig: {
-      index: 0,
-      isWritable: false,
-      value: input.treeConfig ?? null,
-    },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     authority: { index: 2, isWritable: false, value: input.authority ?? null },
     leafOwner: { index: 3, isWritable: false, value: input.leafOwner ?? null },
     leafDelegate: {

--- a/clients/js/src/generated/instructions/transferV2.ts
+++ b/clients/js/src/generated/instructions/transferV2.ts
@@ -132,7 +132,7 @@ export function transferV2(
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
     treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     authority: { index: 2, isWritable: false, value: input.authority ?? null },
     leafOwner: { index: 3, isWritable: false, value: input.leafOwner ?? null },
     leafDelegate: {

--- a/clients/js/src/generated/instructions/unverifyCreatorV2.ts
+++ b/clients/js/src/generated/instructions/unverifyCreatorV2.ts
@@ -130,12 +130,8 @@ export function unverifyCreatorV2(
 
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
-    treeConfig: {
-      index: 0,
-      isWritable: false,
-      value: input.treeConfig ?? null,
-    },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     creator: { index: 2, isWritable: false, value: input.creator ?? null },
     leafOwner: { index: 3, isWritable: false, value: input.leafOwner ?? null },
     leafDelegate: {

--- a/clients/js/src/generated/instructions/updateAssetDataV2.ts
+++ b/clients/js/src/generated/instructions/updateAssetDataV2.ts
@@ -144,12 +144,8 @@ export function updateAssetDataV2(
 
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
-    treeConfig: {
-      index: 0,
-      isWritable: false,
-      value: input.treeConfig ?? null,
-    },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     authority: { index: 2, isWritable: false, value: input.authority ?? null },
     leafOwner: { index: 3, isWritable: false, value: input.leafOwner ?? null },
     leafDelegate: {

--- a/clients/js/src/generated/instructions/updateMetadataV2.ts
+++ b/clients/js/src/generated/instructions/updateMetadataV2.ts
@@ -48,7 +48,6 @@ import {
 // Accounts.
 export type UpdateMetadataV2InstructionAccounts = {
   treeConfig?: PublicKey | Pda;
-  /** Optional payer, defaults to `authority` */
   payer?: Signer;
   /**
    * Either collection authority or tree owner/delegate, depending
@@ -142,12 +141,8 @@ export function updateMetadataV2(
 
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
-    treeConfig: {
-      index: 0,
-      isWritable: false,
-      value: input.treeConfig ?? null,
-    },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     authority: { index: 2, isWritable: false, value: input.authority ?? null },
     leafOwner: { index: 3, isWritable: false, value: input.leafOwner ?? null },
     leafDelegate: {

--- a/clients/js/src/generated/instructions/verifyCreatorV2.ts
+++ b/clients/js/src/generated/instructions/verifyCreatorV2.ts
@@ -130,12 +130,8 @@ export function verifyCreatorV2(
 
   // Accounts.
   const resolvedAccounts: ResolvedAccountsWithIndices = {
-    treeConfig: {
-      index: 0,
-      isWritable: false,
-      value: input.treeConfig ?? null,
-    },
-    payer: { index: 1, isWritable: false, value: input.payer ?? null },
+    treeConfig: { index: 0, isWritable: true, value: input.treeConfig ?? null },
+    payer: { index: 1, isWritable: true, value: input.payer ?? null },
     creator: { index: 2, isWritable: false, value: input.creator ?? null },
     leafOwner: { index: 3, isWritable: false, value: input.leafOwner ?? null },
     leafDelegate: {

--- a/clients/js/src/leafAssetId.ts
+++ b/clients/js/src/leafAssetId.ts
@@ -77,7 +77,7 @@ export async function parseLeafFromMintV2Transaction(
   const collection = transaction.message.accounts[collectionIndex];
 
   if (!collection) {
-    throw new Error('Account at index 7 is missing');
+    throw new Error('Collection account at index 7 is missing');
   }
 
   const programId = context.programs.getPublicKey(

--- a/clients/js/src/leafAssetId.ts
+++ b/clients/js/src/leafAssetId.ts
@@ -82,7 +82,7 @@ export async function parseLeafFromMintV2Transaction(
 
   const programId = context.programs.getPublicKey(
     'mplBubblegum',
-    'BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY'
+    MPL_BUBBLEGUM_PROGRAM_ID
   );
 
   const instructionIndex = collection === programId ? 0 : 1;

--- a/clients/js/test/burn.test.ts
+++ b/clients/js/test/burn.test.ts
@@ -11,7 +11,6 @@ test('it can burn a compressed NFT', async (t) => {
   // Given a tree with a minted NFT.
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi);
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -19,6 +18,7 @@ test('it can burn a compressed NFT', async (t) => {
   });
 
   // When the owner of the NFT burns it.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await burn(umi, {
     leafOwner,
     merkleTree,
@@ -39,13 +39,14 @@ test('it can burn a compressed NFT as a delegated authority', async (t) => {
   // Given a tree with a delegated compressed NFT.
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi);
   const delegateAuthority = generateSigner(umi);
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
     leafOwner: leafOwner.publicKey,
   });
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await delegate(umi, {
     leafOwner,
     previousLeafDelegate: leafOwner.publicKey,
@@ -59,6 +60,7 @@ test('it can burn a compressed NFT as a delegated authority', async (t) => {
   }).sendAndConfirm(umi);
 
   // When the delegated authority burns the NFT.
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await burn(umi, {
     leafOwner: leafOwner.publicKey,
     leafDelegate: delegateAuthority, // <- The delegated authority signs the transaction.

--- a/clients/js/test/burnV2.test.ts
+++ b/clients/js/test/burnV2.test.ts
@@ -27,7 +27,6 @@ test('owner can burn a compressed NFT using V2 instructions', async (t) => {
   // Given a tree with a minted NFT.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi);
   const { metadata, leafIndex } = await mintV2(umi, {
     merkleTree,
@@ -35,6 +34,7 @@ test('owner can burn a compressed NFT using V2 instructions', async (t) => {
   });
 
   // When the owner of the NFT burns it.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await burnV2(umi, {
     authority: leafOwner,
     leafOwner: leafOwner.publicKey,
@@ -56,7 +56,6 @@ test('delegated authority can burn a compressed NFT using V2 instructions', asyn
   // Given a tree with a delegated compressed NFT.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi);
   const delegateAuthority = generateSigner(umi);
   const { metadata, leafIndex } = await mintV2(umi, {
@@ -64,6 +63,7 @@ test('delegated authority can burn a compressed NFT using V2 instructions', asyn
     leafOwner: leafOwner.publicKey,
   });
 
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await delegateV2(umi, {
     leafOwner,
     newLeafDelegate: delegateAuthority.publicKey,
@@ -77,6 +77,7 @@ test('delegated authority can burn a compressed NFT using V2 instructions', asyn
   }).sendAndConfirm(umi);
 
   // When the delegated authority burns the NFT.
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await burnV2(umi, {
     authority: delegateAuthority,
     leafOwner: leafOwner.publicKey,
@@ -101,6 +102,7 @@ test('item set to non-transferrable can be burnt by owner', async (t) => {
   const merkleTree = await createTreeV2(umi);
   const leafOwner = generateSigner(umi);
   const leafOwnerKey = leafOwner.publicKey;
+
   let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   t.is(merkleTreeAccount.tree.sequenceNumber, 0n);
 

--- a/clients/js/test/cancelRedeem.test.ts
+++ b/clients/js/test/cancelRedeem.test.ts
@@ -19,7 +19,6 @@ test('it can cancel the redemption of a compressed NFT', async (t) => {
   // Given a tree with a minted NFT.
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = await generateSignerWithSol(umi);
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -27,6 +26,7 @@ test('it can cancel the redemption of a compressed NFT', async (t) => {
   });
 
   // And given that NFT was redeemed.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await redeem(umi, {
     leafOwner,
     merkleTree,
@@ -36,8 +36,10 @@ test('it can cancel the redemption of a compressed NFT', async (t) => {
     nonce: leafIndex,
     index: leafIndex,
   }).sendAndConfirm(umi);
+
   merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   t.is(merkleTreeAccount.tree.rightMostPath.leaf, defaultPublicKey());
+
   const [voucher] = findVoucherPda(umi, { merkleTree, nonce: leafIndex });
   t.true(await umi.rpc.accountExists(voucher));
 

--- a/clients/js/test/decompressV1.test.ts
+++ b/clients/js/test/decompressV1.test.ts
@@ -26,7 +26,6 @@ test('it can decompress a redeemed compressed NFT', async (t) => {
   // Given a tree with a minted NFT.
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = await generateSignerWithSol(umi);
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -34,6 +33,7 @@ test('it can decompress a redeemed compressed NFT', async (t) => {
   });
 
   // And given that NFT was redeemed.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const dataHash = hashMetadataData(metadata);
   const creatorHash = hashMetadataCreators(metadata.creators);
   await redeem(umi, {
@@ -45,8 +45,10 @@ test('it can decompress a redeemed compressed NFT', async (t) => {
     nonce: leafIndex,
     index: leafIndex,
   }).sendAndConfirm(umi);
+
   merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   t.is(merkleTreeAccount.tree.rightMostPath.leaf, defaultPublicKey());
+
   const [voucher] = findVoucherPda(umi, { merkleTree, nonce: leafIndex });
   t.true(await umi.rpc.accountExists(voucher));
 

--- a/clients/js/test/delegate.test.ts
+++ b/clients/js/test/delegate.test.ts
@@ -16,7 +16,6 @@ test('it can delegate a compressed NFT', async (t) => {
   // Given a tree with a minted NFT.
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi);
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -25,6 +24,7 @@ test('it can delegate a compressed NFT', async (t) => {
 
   // When the owner of the NFT delegates it to another account.
   const newDelegate = generateSigner(umi).publicKey;
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await delegate(umi, {
     leafOwner,
     previousLeafDelegate: leafOwner.publicKey,

--- a/clients/js/test/delegateAndFreezeV2.test.ts
+++ b/clients/js/test/delegateAndFreezeV2.test.ts
@@ -18,7 +18,6 @@ test('owner can delegate and freeze a compressed NFT with V2 instructions', asyn
   // Given a tree with a minted NFT.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi);
   const { metadata, leafIndex } = await mintV2(umi, {
     merkleTree,
@@ -27,6 +26,7 @@ test('owner can delegate and freeze a compressed NFT with V2 instructions', asyn
 
   // When the owner of the NFT delegates it to another account and freezes it.
   const newDelegate = generateSigner(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await delegateAndFreezeV2(umi, {
     leafOwner,
     newLeafDelegate: newDelegate.publicKey,
@@ -56,7 +56,6 @@ test('owner cannot thaw a compressed NFT that was frozen using delegateAndFreeze
   // Given a tree with a minted NFT.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi);
   const { metadata, leafIndex } = await mintV2(umi, {
     merkleTree,
@@ -65,6 +64,7 @@ test('owner cannot thaw a compressed NFT that was frozen using delegateAndFreeze
 
   // When the owner of the NFT delegates it to another account and freezes it.
   const newDelegate = generateSigner(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await delegateAndFreezeV2(umi, {
     leafOwner,
     newLeafDelegate: newDelegate.publicKey,

--- a/clients/js/test/mintToCollectionV1AndTransfer.test.ts
+++ b/clients/js/test/mintToCollectionV1AndTransfer.test.ts
@@ -73,7 +73,6 @@ test('it can mint an NFT from a collection and then transfer it', async (t) => {
   });
   t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(leaf));
 
-  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const updatedMetadata = {
     ...metadata,
     collection: some({ key: collectionMint.publicKey, verified: true }),

--- a/clients/js/test/mintV2_only.test.ts
+++ b/clients/js/test/mintV2_only.test.ts
@@ -36,7 +36,6 @@ test('it can mint a compressed NFT with a separate payer', async (t) => {
   // Given a tree with a minted NFT owned by leafOwnerA.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwnerA = generateSigner(umi);
   const payer = generateSigner(umi);
   await umi.rpc.airdrop(payer.publicKey, sol(1));
@@ -54,7 +53,7 @@ test('it can mint a compressed NFT with a separate payer', async (t) => {
     leafIndex,
     metadata,
   });
-  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(leaf));
 });
 

--- a/clients/js/test/parseMintV1.test.ts
+++ b/clients/js/test/parseMintV1.test.ts
@@ -55,7 +55,7 @@ test('it can parse the leaf from mint instructions', async (t) => {
   }
 });
 
-test('it can parse the leaf from mintToCollection instructions)', async (t) => {
+test('it can parse the leaf from mintToCollection instructions', async (t) => {
   // Given an empty Bubblegum tree.
   const umi = await createUmi();
   const merkleTree = await createTree(umi);

--- a/clients/js/test/parseMintV2.test.ts
+++ b/clients/js/test/parseMintV2.test.ts
@@ -53,7 +53,7 @@ test('it can parse the leaf from mintV2 instructions', async (t) => {
   }
 });
 
-test('it can parse the leaf from mintV2 to collection instructions)', async (t) => {
+test('it can parse the leaf from mintV2 to collection instructions', async (t) => {
   // Given an empty Bubblegum tree.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);

--- a/clients/js/test/redeem.test.ts
+++ b/clients/js/test/redeem.test.ts
@@ -20,7 +20,6 @@ test('it can redeem a compressed NFT', async (t) => {
   // Given a tree with a minted NFT.
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = await generateSignerWithSol(umi);
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -28,6 +27,7 @@ test('it can redeem a compressed NFT', async (t) => {
   });
 
   // When leaf owner redeems the compressed NFT.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const dataHash = hashMetadataData(metadata);
   const creatorHash = hashMetadataCreators(metadata.creators);
   await redeem(umi, {

--- a/clients/js/test/setAndVerifyCollection.test.ts
+++ b/clients/js/test/setAndVerifyCollection.test.ts
@@ -30,7 +30,6 @@ test('it can set and verify the collection of a minted compressed NFT', async (t
   // And a tree with a minted NFT that has no collection.
   const treeCreator = await generateSignerWithSol(umi);
   const merkleTree = await createTree(umi, { treeCreator });
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -39,6 +38,7 @@ test('it can set and verify the collection of a minted compressed NFT', async (t
   });
 
   // When the collection authority sets and verifies the collection.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await setAndVerifyCollection(umi, {
     leafOwner,
     treeCreatorOrDelegate: treeCreator,
@@ -86,7 +86,6 @@ test('it cannot set and verify the collection if the tree creator or delegate do
   // And a tree with a minted NFT that has no collection.
   const treeCreator = await generateSignerWithSol(umi);
   const merkleTree = await createTree(umi, { treeCreator });
-  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -96,6 +95,7 @@ test('it cannot set and verify the collection if the tree creator or delegate do
 
   // When the collection authority sets and verifies the collection
   // without the tree creator signing.
+  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const promise = setAndVerifyCollection(umi, {
     leafOwner,
     treeCreatorOrDelegate: treeCreator.publicKey, // <-- Here, we pass the tree creator as a public key.
@@ -130,13 +130,14 @@ test('it cannot set and verify the collection if there is already a verified col
   // And a tree with a minted NFT that has a verified collection of that first Collection NFT.
   const treeCreator = await generateSignerWithSol(umi);
   const merkleTree = await createTree(umi, { treeCreator });
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
     treeCreatorOrDelegate: treeCreator,
     leafOwner,
   });
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await setAndVerifyCollection(umi, {
     leafOwner,
     treeCreatorOrDelegate: treeCreator,
@@ -169,6 +170,7 @@ test('it cannot set and verify the collection if there is already a verified col
   }).sendAndConfirm(umi);
 
   // When the second collection authority attempts to set and verify the second collection.
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const promise = setAndVerifyCollection(umi, {
     leafOwner,
     treeCreatorOrDelegate: treeCreator,

--- a/clients/js/test/setCollectionV2.test.ts
+++ b/clients/js/test/setCollectionV2.test.ts
@@ -71,8 +71,6 @@ test('it can mint an NFT to a collection and then remove it from collection usin
   });
   t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(leaf));
 
-  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
-
   // When collection update authority removes it from the collection.
   await setCollectionV2(umi, {
     authority: collectionUpdateAuthority,
@@ -150,8 +148,6 @@ test('it can mint an NFT not in a collection then add it to collection using V2 
       },
     ],
   }).sendAndConfirm(umi);
-
-  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
 
   // Then add the leaf to the collection.
   await setCollectionV2(umi, {
@@ -247,8 +243,6 @@ test('it can mint an NFT to a collection and move it to a new collection using V
       },
     ],
   }).sendAndConfirm(umi);
-
-  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
 
   // Then add the leaf to the collection.
   await setCollectionV2(umi, {

--- a/clients/js/test/thawV2.test.ts
+++ b/clients/js/test/thawV2.test.ts
@@ -34,7 +34,6 @@ test('delegate can thaw a compressed NFT using V2 instructions', async (t) => {
   // Given a tree with a minted NFT.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi);
   const { metadata, leafIndex } = await mintV2(umi, {
     merkleTree,
@@ -43,6 +42,7 @@ test('delegate can thaw a compressed NFT using V2 instructions', async (t) => {
 
   // When the owner of the NFT delegates it to another account.
   const newDelegate = generateSigner(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await delegateV2(umi, {
     leafOwner,
     newLeafDelegate: newDelegate.publicKey,
@@ -124,7 +124,6 @@ test('owner cannot thaw a compressed NFT using V2 instructions', async (t) => {
   // Given a tree with a minted NFT.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi);
   const { metadata, leafIndex } = await mintV2(umi, {
     merkleTree,
@@ -133,6 +132,7 @@ test('owner cannot thaw a compressed NFT using V2 instructions', async (t) => {
 
   // When the owner of the NFT delegates it to another account.
   const newDelegate = generateSigner(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await delegateV2(umi, {
     leafOwner,
     newLeafDelegate: newDelegate.publicKey,
@@ -208,7 +208,6 @@ test('owner as default leaf delegate can thaw a compressed NFT it previously fro
   // Given a tree with a minted NFT.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi);
   const { metadata, leafIndex } = await mintV2(umi, {
     merkleTree,
@@ -216,6 +215,7 @@ test('owner as default leaf delegate can thaw a compressed NFT it previously fro
   });
 
   // When the owner of the NFT freezes it.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await freezeV2(umi, {
     authority: leafOwner,
     leafOwner: leafOwner.publicKey,
@@ -296,7 +296,6 @@ test('can thaw a compressed NFT using the getAssetWithProof helper using V2 inst
   });
 
   // And given we mock the RPC client to return the following asset and proof.
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const [assetId] = findLeafAssetIdPda(umi, { merkleTree, leafIndex });
   const rpcAsset = {
     ownership: {
@@ -313,6 +312,8 @@ test('can thaw a compressed NFT using the getAssetWithProof helper using V2 inst
       flags: LeafSchemaV2Flags.None,
     },
   } as DasApiAsset;
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const rpcAssetProof = {
     proof: getMerkleProof([...preMints.map((m) => m.leaf), leaf], 5, leaf),
     root: publicKey(getCurrentRoot(merkleTreeAccount.tree)),
@@ -359,6 +360,7 @@ test('can thaw a compressed NFT using the getAssetWithProof helper using V2 inst
   // When we get an updated value from the helper.
   rpcAsset.compression.flags = 1;
   rpcAsset.ownership.frozen = true;
+  rpcAssetProof.root = publicKey(getCurrentRoot(merkleTreeAccount.tree));
   assetWithProof = await getAssetWithProof(umi, assetId);
 
   // Check using the `canTransfer` helper.

--- a/clients/js/test/transfer.test.ts
+++ b/clients/js/test/transfer.test.ts
@@ -26,7 +26,6 @@ test('it can transfer a compressed NFT', async (t) => {
   // Given a tree with a minted NFT owned by leafOwnerA.
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwnerA = generateSigner(umi);
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -35,6 +34,7 @@ test('it can transfer a compressed NFT', async (t) => {
 
   // When leafOwnerA transfers the NFT to leafOwnerB.
   const leafOwnerB = generateSigner(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await transfer(umi, {
     leafOwner: leafOwnerA,
     newLeafOwner: leafOwnerB.publicKey,
@@ -62,13 +62,14 @@ test('it can transfer a compressed NFT as a delegated authority', async (t) => {
   // Given a tree with a delegated compressed NFT owned by leafOwnerA.
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwnerA = generateSigner(umi);
   const delegateAuthority = generateSigner(umi);
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
     leafOwner: leafOwnerA.publicKey,
   });
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await delegate(umi, {
     leafOwner: leafOwnerA,
     previousLeafDelegate: leafOwnerA.publicKey,
@@ -83,6 +84,7 @@ test('it can transfer a compressed NFT as a delegated authority', async (t) => {
 
   // When the delegated authority transfers the NFT to leafOwnerB.
   const leafOwnerB = generateSigner(umi);
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await transfer(umi, {
     leafDelegate: delegateAuthority, // <- The delegated authority signs the transaction.
     leafOwner: leafOwnerA.publicKey,
@@ -118,7 +120,6 @@ test('it can transfer a compressed NFT using a proof', async (t) => {
     maxDepth: 5,
     maxBufferSize: 8,
   });
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const preMints = [
     await mint(umi, { merkleTree, leafIndex: 0 }),
     await mint(umi, { merkleTree, leafIndex: 1 }),
@@ -143,6 +144,7 @@ test('it can transfer a compressed NFT using a proof', async (t) => {
 
   // When leafOwnerA transfers the NFT to leafOwnerB.
   const leafOwnerB = generateSigner(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await transfer(umi, {
     leafOwner: leafOwnerA,
     newLeafOwner: leafOwnerB.publicKey,
@@ -162,11 +164,13 @@ test('it can transfer a compressed NFT using a proof', async (t) => {
     leafIndex,
     metadata,
   });
+
   const updatedProof = getMerkleProof(
     [...preMints.map((m) => m.leaf), publicKey(updatedLeaf)],
     5,
     publicKey(updatedLeaf)
   );
+
   merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await verifyLeaf(umi, {
     merkleTree,
@@ -205,7 +209,6 @@ test('it can transfer a compressed NFT using the getAssetWithProof helper', asyn
   });
 
   // And given we mock the RPC client to return the following asset and proof.
-  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const [assetId] = findLeafAssetIdPda(umi, { merkleTree, leafIndex });
   const rpcAsset = {
     ownership: { owner: leafOwnerA.publicKey },
@@ -215,6 +218,8 @@ test('it can transfer a compressed NFT using the getAssetWithProof helper', asyn
       creator_hash: publicKey(hashMetadataCreators(metadata.creators)),
     },
   } as DasApiAsset;
+
+  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const rpcAssetProof = {
     proof: getMerkleProof([...preMints.map((m) => m.leaf), leaf], 5, leaf),
     root: publicKey(getCurrentRoot(merkleTreeAccount.tree)),

--- a/clients/js/test/transferV2.test.ts
+++ b/clients/js/test/transferV2.test.ts
@@ -3,7 +3,9 @@ import {
   generateSigner,
   publicKey,
   defaultPublicKey,
+  sol,
 } from '@metaplex-foundation/umi';
+import { generateSignerWithSol } from '@metaplex-foundation/umi-bundle-tests';
 import test from 'ava';
 import {
   DasApiAsset,
@@ -34,7 +36,6 @@ test('owner can transfer a compressed NFT using V2 instructions', async (t) => {
   // Given a tree with a minted NFT owned by leafOwnerA.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwnerA = generateSigner(umi);
   const { metadata, leafIndex } = await mintV2(umi, {
     merkleTree,
@@ -43,6 +44,7 @@ test('owner can transfer a compressed NFT using V2 instructions', async (t) => {
 
   // When leafOwnerA transfers the NFT to leafOwnerB.
   const leafOwnerB = generateSigner(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await transferV2(umi, {
     authority: leafOwnerA,
     leafOwner: leafOwnerA.publicKey,
@@ -67,17 +69,101 @@ test('owner can transfer a compressed NFT using V2 instructions', async (t) => {
   t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(updatedLeaf));
 });
 
+test('owner can transfer a compressed NFT with a separate payer', async (t) => {
+  // Given a tree with a minted NFT owned by leafOwnerA.
+  const umi = await createUmi();
+  const merkleTree = await createTreeV2(umi);
+  const leafOwnerA = generateSigner(umi);
+  const { metadata, leafIndex } = await mintV2(umi, {
+    merkleTree,
+    leafOwner: leafOwnerA.publicKey,
+  });
+
+  // When leafOwnerA transfers the NFT to leafOwnerB.
+  const payer = generateSigner(umi);
+  await umi.rpc.airdrop(payer.publicKey, sol(1));
+
+  const leafOwnerB = generateSigner(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  await transferV2(umi, {
+    payer,
+    authority: leafOwnerA,
+    leafOwner: leafOwnerA.publicKey,
+    newLeafOwner: leafOwnerB.publicKey,
+    merkleTree,
+    root: getCurrentRoot(merkleTreeAccount.tree),
+    dataHash: hashMetadataDataV2(metadata),
+    creatorHash: hashMetadataCreators(metadata.creators),
+    nonce: leafIndex,
+    index: leafIndex,
+    proof: [],
+  }).sendAndConfirm(umi);
+
+  // Then the leaf was updated in the merkle tree.
+  const updatedLeaf = hashLeafV2(umi, {
+    merkleTree,
+    owner: leafOwnerB.publicKey,
+    leafIndex,
+    metadata,
+  });
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(updatedLeaf));
+});
+
+test('update authority cannot transfer a compressed NFT using V2 instructions', async (t) => {
+  // Given a tree with a minted NFT owned by leafOwnerA.
+  const umi = await createUmi();
+  const treeCreator = await generateSignerWithSol(umi);
+  const merkleTree = await createTreeV2(umi, { treeCreator });
+  const leafOwnerA = generateSigner(umi);
+  const { metadata, leafIndex } = await mintV2(umi, {
+    treeCreatorOrDelegate: treeCreator,
+    merkleTree,
+    leafOwner: leafOwnerA.publicKey,
+  });
+
+  // When leafOwnerA transfers the NFT to leafOwnerB.
+  const leafOwnerB = generateSigner(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  const promise = transferV2(umi, {
+    authority: treeCreator,
+    leafOwner: leafOwnerA.publicKey,
+    newLeafOwner: leafOwnerB.publicKey,
+    merkleTree,
+    root: getCurrentRoot(merkleTreeAccount.tree),
+    dataHash: hashMetadataDataV2(metadata),
+    creatorHash: hashMetadataCreators(metadata.creators),
+    nonce: leafIndex,
+    index: leafIndex,
+    proof: [],
+  }).sendAndConfirm(umi);
+
+  // We expect a failure.
+  await t.throwsAsync(promise, { name: 'InvalidAuthority' });
+
+  // Then the leaf was not updated in the merkle tree.
+  const notUpdatedLeaf = hashLeafV2(umi, {
+    merkleTree,
+    owner: leafOwnerA.publicKey,
+    leafIndex,
+    metadata,
+  });
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
+  t.is(merkleTreeAccount.tree.rightMostPath.leaf, publicKey(notUpdatedLeaf));
+});
+
 test('leaf delegate can transfer a compressed NFT using V2 instructions', async (t) => {
   // Given a tree with a delegated compressed NFT owned by leafOwnerA.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwnerA = generateSigner(umi);
   const delegateAuthority = generateSigner(umi);
   const { metadata, leafIndex } = await mintV2(umi, {
     merkleTree,
     leafOwner: leafOwnerA.publicKey,
   });
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await delegateV2(umi, {
     leafOwner: leafOwnerA,
     previousLeafDelegate: leafOwnerA.publicKey,
@@ -92,6 +178,7 @@ test('leaf delegate can transfer a compressed NFT using V2 instructions', async 
 
   // When the delegated authority transfers the NFT to leafOwnerB.
   const leafOwnerB = generateSigner(umi);
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await transferV2(umi, {
     authority: delegateAuthority, // <- The delegated authority signs the transaction.
     leafOwner: leafOwnerA.publicKey,
@@ -128,7 +215,6 @@ test('owner can transfer a compressed NFT using a proof', async (t) => {
     maxDepth: 5,
     maxBufferSize: 8,
   });
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const preMints = [
     await mintV2(umi, { merkleTree, leafIndex: 0 }),
     await mintV2(umi, { merkleTree, leafIndex: 1 }),
@@ -153,6 +239,7 @@ test('owner can transfer a compressed NFT using a proof', async (t) => {
 
   // When leafOwnerA transfers the NFT to leafOwnerB.
   const leafOwnerB = generateSigner(umi);
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await transferV2(umi, {
     authority: leafOwnerA,
     leafOwner: leafOwnerA.publicKey,
@@ -173,11 +260,13 @@ test('owner can transfer a compressed NFT using a proof', async (t) => {
     leafIndex,
     metadata,
   });
+
   const updatedProof = getMerkleProof(
     [...preMints.map((m) => m.leaf), publicKey(updatedLeaf)],
     5,
     publicKey(updatedLeaf)
   );
+
   merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await verifyLeaf(umi, {
     merkleTree,
@@ -216,7 +305,6 @@ test('owner can transfer a compressed NFT using the getAssetWithProof helper', a
   });
 
   // And given we mock the RPC client to return the following asset and proof.
-  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const [assetId] = findLeafAssetIdPda(umi, { merkleTree, leafIndex });
   const rpcAsset = {
     ownership: {
@@ -233,6 +321,8 @@ test('owner can transfer a compressed NFT using the getAssetWithProof helper', a
       flags: LeafSchemaV2Flags.None,
     },
   } as DasApiAsset;
+
+  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const rpcAssetProof = {
     proof: getMerkleProof([...preMints.map((m) => m.leaf), leaf], 5, leaf),
     root: publicKey(getCurrentRoot(merkleTreeAccount.tree)),

--- a/clients/js/test/unverifyCollection.test.ts
+++ b/clients/js/test/unverifyCollection.test.ts
@@ -28,9 +28,10 @@ test('it can unverify the collection of a minted compressed NFT', async (t) => {
 
   // And a tree with a minted NFT that has a verified collection.
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, { merkleTree, leafOwner });
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await setAndVerifyCollection(umi, {
     leafOwner,
     collectionMint: collectionMint.publicKey,
@@ -50,6 +51,7 @@ test('it can unverify the collection of a minted compressed NFT', async (t) => {
   };
 
   // When the collection authority unverifies the collection.
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await unverifyCollection(umi, {
     leafOwner,
     collectionMint: collectionMint.publicKey,
@@ -95,7 +97,6 @@ test('it cannot unverify the collection if it is already unverified', async (t) 
 
   // And a tree with a minted NFT that has an unverified collection.
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -109,6 +110,7 @@ test('it cannot unverify the collection if it is already unverified', async (t) 
   });
 
   // When the collection authority attempts to unverify the collection.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const promise = unverifyCollection(umi, {
     leafOwner,
     collectionMint: collectionMint.publicKey,

--- a/clients/js/test/unverifyCreator.test.ts
+++ b/clients/js/test/unverifyCreator.test.ts
@@ -13,7 +13,6 @@ test('it can unverify the creator of a minted compressed NFT', async (t) => {
   const creatorA = generateSigner(umi);
   const creatorB = generateSigner(umi);
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -30,10 +29,10 @@ test('it can unverify the creator of a minted compressed NFT', async (t) => {
   const commonArgs = {
     leafOwner,
     merkleTree,
-    root: getCurrentRoot(merkleTreeAccount.tree),
     nonce: leafIndex,
     index: leafIndex,
   };
+
   const partiallyVerifiedMetadata = {
     ...metadata,
     creators: [
@@ -41,14 +40,18 @@ test('it can unverify the creator of a minted compressed NFT', async (t) => {
       { address: creatorB.publicKey, verified: false, share: 40 },
     ],
   };
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await verifyCreator(umi, {
     ...commonArgs,
+    root: getCurrentRoot(merkleTreeAccount.tree),
     creator: creatorA,
     metadata,
   })
     .add(
       verifyCreator(umi, {
         ...commonArgs,
+        root: getCurrentRoot(merkleTreeAccount.tree),
         creator: creatorB,
         metadata: partiallyVerifiedMetadata,
       })
@@ -63,8 +66,11 @@ test('it can unverify the creator of a minted compressed NFT', async (t) => {
       { address: creatorB.publicKey, verified: true, share: 40 },
     ],
   };
+
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await unverifyCreator(umi, {
     ...commonArgs,
+    root: getCurrentRoot(merkleTreeAccount.tree),
     creator: creatorA,
     metadata: verifiedMetadata,
     proof: [],

--- a/clients/js/test/unverifyCreatorV2.test.ts
+++ b/clients/js/test/unverifyCreatorV2.test.ts
@@ -13,7 +13,6 @@ test('it can unverify the creator of a minted compressed NFT', async (t) => {
   const creatorA = generateSigner(umi);
   const creatorB = generateSigner(umi);
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mintV2(umi, {
     merkleTree,
@@ -30,10 +29,10 @@ test('it can unverify the creator of a minted compressed NFT', async (t) => {
   const commonArgs = {
     leafOwner,
     merkleTree,
-    root: getCurrentRoot(merkleTreeAccount.tree),
     nonce: leafIndex,
     index: leafIndex,
   };
+
   const partiallyVerifiedMetadata = {
     ...metadata,
     creators: [
@@ -41,14 +40,18 @@ test('it can unverify the creator of a minted compressed NFT', async (t) => {
       { address: creatorB.publicKey, verified: false, share: 40 },
     ],
   };
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await verifyCreatorV2(umi, {
     ...commonArgs,
+    root: getCurrentRoot(merkleTreeAccount.tree),
     creator: creatorA,
     metadata,
   })
     .add(
       verifyCreatorV2(umi, {
         ...commonArgs,
+        root: getCurrentRoot(merkleTreeAccount.tree),
         creator: creatorB,
         metadata: partiallyVerifiedMetadata,
       })
@@ -63,8 +66,11 @@ test('it can unverify the creator of a minted compressed NFT', async (t) => {
       { address: creatorB.publicKey, verified: true, share: 40 },
     ],
   };
+
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await unverifyCreatorV2(umi, {
     ...commonArgs,
+    root: getCurrentRoot(merkleTreeAccount.tree),
     creator: creatorA,
     metadata: verifiedMetadata,
     proof: [],

--- a/clients/js/test/updateAssetDataV2.test.ts
+++ b/clients/js/test/updateAssetDataV2.test.ts
@@ -16,7 +16,6 @@ test('it cannot update asset data using V2 instructions', async (t) => {
   // Given a tree with a minted NFT.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi);
   const { metadata, leafIndex } = await mintV2(umi, {
     merkleTree,
@@ -24,6 +23,7 @@ test('it cannot update asset data using V2 instructions', async (t) => {
   });
 
   // When the authority of the NFT attempts to update the asset data.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const promise = updateAssetDataV2(umi, {
     leafOwner: leafOwner.publicKey,
     merkleTree,

--- a/clients/js/test/updateMetadata.test.ts
+++ b/clients/js/test/updateMetadata.test.ts
@@ -139,7 +139,6 @@ test('it can update metadata using the getAssetWithProof helper', async (t) => {
   });
 
   // And given we mock the RPC client to return the following asset and proof.
-  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const [assetId] = findLeafAssetIdPda(umi, { merkleTree, leafIndex });
   const rpcAsset = {
     ownership: { owner: leafOwner },
@@ -149,6 +148,8 @@ test('it can update metadata using the getAssetWithProof helper', async (t) => {
       creator_hash: publicKey(hashMetadataCreators(metadata.creators)),
     },
   } as DasApiAsset;
+
+  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const rpcAssetProof = {
     proof: getMerkleProof([...preMints.map((m) => m.leaf), leaf], 5, leaf),
     root: publicKey(getCurrentRoot(merkleTreeAccount.tree)),
@@ -193,7 +194,6 @@ test('it cannot update metadata using collection update authority when collectio
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
   const leafOwner = generateSigner(umi).publicKey;
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
 
   // And a Collection NFT.
   const collectionMint = generateSigner(umi);
@@ -221,6 +221,8 @@ test('it cannot update metadata using collection update authority when collectio
     name: some('New name'),
     uri: some('https://updated-example.com/my-nft.json'),
   };
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const promise = updateMetadata(umi, {
     leafOwner,
     merkleTree,
@@ -253,7 +255,6 @@ test('it can update metadata using collection update authority when collection i
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
   const leafOwner = generateSigner(umi).publicKey;
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
 
   // And a Collection NFT.
   const collectionMint = generateSigner(umi);
@@ -291,6 +292,8 @@ test('it can update metadata using collection update authority when collection i
     name: some('New name'),
     uri: some('https://updated-example.com/my-nft.json'),
   };
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await updateMetadata(umi, {
     leafOwner,
     merkleTree,
@@ -324,7 +327,6 @@ test('it can update metadata using old collection authority when collection is v
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
   const leafOwner = generateSigner(umi).publicKey;
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
 
   // And a Collection NFT.
   const collectionMint = generateSigner(umi);
@@ -376,6 +378,8 @@ test('it can update metadata using old collection authority when collection is v
     name: some('New name'),
     uri: some('https://updated-example.com/my-nft.json'),
   };
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await updateMetadata(umi, {
     leafOwner,
     merkleTree,
@@ -410,7 +414,6 @@ test('it can update metadata using collection data delegate when collection is v
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
   const leafOwner = generateSigner(umi).publicKey;
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
 
   // And a Collection NFT.
   const collectionMint = generateSigner(umi);
@@ -464,6 +467,8 @@ test('it can update metadata using collection data delegate when collection is v
     name: some('New name'),
     uri: some('https://updated-example.com/my-nft.json'),
   };
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await updateMetadata(umi, {
     leafOwner,
     merkleTree,
@@ -498,7 +503,6 @@ test('it cannot update metadata using collection collection delegate when collec
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
   const leafOwner = generateSigner(umi).publicKey;
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
 
   // And a Collection NFT.
   const collectionMint = generateSigner(umi);
@@ -552,6 +556,8 @@ test('it cannot update metadata using collection collection delegate when collec
     name: some('New name'),
     uri: some('https://updated-example.com/my-nft.json'),
   };
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const promise = updateMetadata(umi, {
     leafOwner,
     merkleTree,
@@ -640,7 +646,6 @@ test('it can update metadata using the getAssetWithProof helper with verified co
   );
 
   // And given we mock the RPC client to return the following asset and proof.
-  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const [assetId] = findLeafAssetIdPda(umi, { merkleTree, leafIndex });
   const rpcAsset = {
     ownership: { owner: leafOwner },
@@ -650,6 +655,8 @@ test('it can update metadata using the getAssetWithProof helper with verified co
       creator_hash: publicKey(hashMetadataCreators(metadata.creators)),
     },
   } as DasApiAsset;
+
+  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const rpcAssetProof = {
     proof: getMerkleProof([...preMints.map((m) => m.leaf), leaf], 5, leaf),
     root: publicKey(getCurrentRoot(merkleTreeAccount.tree)),
@@ -697,7 +704,6 @@ test('it cannot update metadata using tree owner when collection is verified', a
   const treeCreator = await generateSignerWithSol(umi);
   const merkleTree = await createTree(umi, { treeCreator });
   const leafOwner = generateSigner(umi).publicKey;
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
 
   // And a Collection NFT.
   const collectionMint = generateSigner(umi);
@@ -736,6 +742,8 @@ test('it cannot update metadata using tree owner when collection is verified', a
     name: some('New name'),
     uri: some('https://updated-example.com/my-nft.json'),
   };
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const promise = updateMetadata(umi, {
     leafOwner,
     merkleTree,
@@ -768,7 +776,6 @@ test('it cannot update immutable metadata', async (t) => {
   const umi = await createUmi();
   const merkleTree = await createTree(umi);
   const leafOwner = generateSigner(umi).publicKey;
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
 
   // When we mint a new NFT from the tree.
   const { metadata, leafIndex } = await mint(umi, {
@@ -777,6 +784,7 @@ test('it cannot update immutable metadata', async (t) => {
   });
 
   // And we set the NFT to immutable.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await updateMetadata(umi, {
     leafOwner,
     merkleTree,
@@ -837,7 +845,6 @@ test('it cannot verify currently unverified creator if not signer', async (t) =>
   const creatorA = generateSigner(umi);
   const creatorB = generateSigner(umi);
   const merkleTree = await createTree(umi);
-  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -850,6 +857,7 @@ test('it cannot verify currently unverified creator if not signer', async (t) =>
     },
   });
 
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await verifyCreator(umi, {
     leafOwner,
     creator: creatorA,
@@ -861,6 +869,7 @@ test('it cannot verify currently unverified creator if not signer', async (t) =>
     proof: [],
   }).sendAndConfirm(umi);
 
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const promise = updateMetadata(umi, {
     leafOwner,
     merkleTree,
@@ -893,7 +902,6 @@ test('it can verify currently unverified creator if signer', async (t) => {
   const creatorA = umi.identity;
   const creatorB = generateSigner(umi);
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -914,6 +922,7 @@ test('it can verify currently unverified creator if signer', async (t) => {
     ],
   };
 
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await updateMetadata(umi, {
     leafOwner,
     merkleTree,
@@ -944,7 +953,6 @@ test('it cannot unverify currently verified creator if not signer', async (t) =>
   const creatorA = generateSigner(umi);
   const creatorB = generateSigner(umi);
   const merkleTree = await createTree(umi);
-  const merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -957,6 +965,7 @@ test('it cannot unverify currently verified creator if not signer', async (t) =>
     },
   });
 
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await verifyCreator(umi, {
     leafOwner,
     creator: creatorA,
@@ -976,6 +985,7 @@ test('it cannot unverify currently verified creator if not signer', async (t) =>
     ],
   };
 
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const promise = updateMetadata(umi, {
     leafOwner,
     merkleTree,
@@ -1001,7 +1011,6 @@ test('it can unverify currently verified creator if signer', async (t) => {
   const creatorA = umi.identity;
   const creatorB = generateSigner(umi);
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -1022,6 +1031,7 @@ test('it can unverify currently verified creator if signer', async (t) => {
     ],
   };
 
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await updateMetadata(umi, {
     leafOwner,
     merkleTree,
@@ -1052,7 +1062,6 @@ test('it can remove currently verified creator using empty creator array if sign
   const creatorA = umi.identity;
   const creatorB = generateSigner(umi);
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -1070,6 +1079,7 @@ test('it can remove currently verified creator using empty creator array if sign
     creators: [],
   };
 
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await updateMetadata(umi, {
     leafOwner,
     merkleTree,
@@ -1100,7 +1110,6 @@ test('it cannot unverify currently verified creator using empty creator array if
   const creatorA = generateSigner(umi);
   const creatorB = generateSigner(umi);
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -1113,6 +1122,7 @@ test('it cannot unverify currently verified creator using empty creator array if
     },
   });
 
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await verifyCreator(umi, {
     leafOwner,
     creator: creatorA,
@@ -1129,6 +1139,7 @@ test('it cannot unverify currently verified creator using empty creator array if
     creators: [],
   };
 
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const promise = updateMetadata(umi, {
     leafOwner,
     merkleTree,

--- a/clients/js/test/verifyCollection.test.ts
+++ b/clients/js/test/verifyCollection.test.ts
@@ -28,7 +28,6 @@ test('it can verify the collection of a minted compressed NFT', async (t) => {
 
   // And a tree with a minted NFT that has an unverified collection.
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -42,6 +41,7 @@ test('it can verify the collection of a minted compressed NFT', async (t) => {
   });
 
   // When the collection authority verifies the collection.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await verifyCollection(umi, {
     leafOwner,
     collectionMint: collectionMint.publicKey,
@@ -87,9 +87,10 @@ test('it cannot verify the collection if it is already verified', async (t) => {
 
   // And a tree with a minted NFT that has a verified collection.
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, { merkleTree, leafOwner });
+
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await setAndVerifyCollection(umi, {
     leafOwner,
     collectionMint: collectionMint.publicKey,
@@ -109,6 +110,7 @@ test('it cannot verify the collection if it is already verified', async (t) => {
   };
 
   // When the collection authority attempts to verify the collection.
+  merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const promise = verifyCollection(umi, {
     leafOwner,
     collectionMint: collectionMint.publicKey,

--- a/clients/js/test/verifyCreator.test.ts
+++ b/clients/js/test/verifyCreator.test.ts
@@ -13,7 +13,6 @@ test('it can verify the creator of a minted compressed NFT', async (t) => {
   const creatorA = generateSigner(umi);
   const creatorB = generateSigner(umi);
   const merkleTree = await createTree(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mint(umi, {
     merkleTree,
@@ -27,6 +26,7 @@ test('it can verify the creator of a minted compressed NFT', async (t) => {
   });
 
   // When creator A verifies themselves.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await verifyCreator(umi, {
     leafOwner,
     creator: creatorA,

--- a/clients/js/test/verifyCreatorV2.test.ts
+++ b/clients/js/test/verifyCreatorV2.test.ts
@@ -13,7 +13,6 @@ test('it can verify the creator of a minted compressed NFT using V2 instructions
   const creatorA = generateSigner(umi);
   const creatorB = generateSigner(umi);
   const merkleTree = await createTreeV2(umi);
-  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   const leafOwner = generateSigner(umi).publicKey;
   const { metadata, leafIndex } = await mintV2(umi, {
     merkleTree,
@@ -27,6 +26,7 @@ test('it can verify the creator of a minted compressed NFT using V2 instructions
   });
 
   // When creator A verifies themselves.
+  let merkleTreeAccount = await fetchMerkleTree(umi, merkleTree);
   await verifyCreatorV2(umi, {
     creator: creatorA,
     leafOwner,

--- a/clients/rust/src/generated/instructions/delegate_and_freeze_v2.rs
+++ b/clients/rust/src/generated/instructions/delegate_and_freeze_v2.rs
@@ -43,11 +43,11 @@ impl DelegateAndFreezeV2 {
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(leaf_owner) = self.leaf_owner {
@@ -418,11 +418,11 @@ impl<'a, 'b> DelegateAndFreezeV2Cpi<'a, 'b> {
         )],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));

--- a/clients/rust/src/generated/instructions/delegate_v2.rs
+++ b/clients/rust/src/generated/instructions/delegate_v2.rs
@@ -43,11 +43,11 @@ impl DelegateV2 {
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(leaf_owner) = self.leaf_owner {
@@ -416,11 +416,11 @@ impl<'a, 'b> DelegateV2Cpi<'a, 'b> {
         )],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));

--- a/clients/rust/src/generated/instructions/freeze_v2.rs
+++ b/clients/rust/src/generated/instructions/freeze_v2.rs
@@ -46,11 +46,11 @@ impl FreezeV2 {
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(authority) = self.authority {
@@ -423,11 +423,11 @@ impl<'a, 'b> FreezeV2Cpi<'a, 'b> {
         )],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));

--- a/clients/rust/src/generated/instructions/set_collection_v2.rs
+++ b/clients/rust/src/generated/instructions/set_collection_v2.rs
@@ -57,11 +57,11 @@ impl SetCollectionV2 {
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(authority) = self.authority {
@@ -543,11 +543,11 @@ impl<'a, 'b> SetCollectionV2Cpi<'a, 'b> {
         )],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));

--- a/clients/rust/src/generated/instructions/set_non_transferable_v2.rs
+++ b/clients/rust/src/generated/instructions/set_non_transferable_v2.rs
@@ -46,11 +46,11 @@ impl SetNonTransferableV2 {
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(authority) = self.authority {
@@ -429,11 +429,11 @@ impl<'a, 'b> SetNonTransferableV2Cpi<'a, 'b> {
         )],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));

--- a/clients/rust/src/generated/instructions/thaw_and_revoke_v2.rs
+++ b/clients/rust/src/generated/instructions/thaw_and_revoke_v2.rs
@@ -41,11 +41,11 @@ impl ThawAndRevokeV2 {
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(leaf_delegate) = self.leaf_delegate {
@@ -385,11 +385,11 @@ impl<'a, 'b> ThawAndRevokeV2Cpi<'a, 'b> {
         )],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));

--- a/clients/rust/src/generated/instructions/thaw_v2.rs
+++ b/clients/rust/src/generated/instructions/thaw_v2.rs
@@ -46,11 +46,11 @@ impl ThawV2 {
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(authority) = self.authority {
@@ -423,11 +423,11 @@ impl<'a, 'b> ThawV2Cpi<'a, 'b> {
         )],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));

--- a/clients/rust/src/generated/instructions/transfer_v2.rs
+++ b/clients/rust/src/generated/instructions/transfer_v2.rs
@@ -52,7 +52,7 @@ impl TransferV2 {
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(authority) = self.authority {
@@ -457,7 +457,7 @@ impl<'a, 'b> TransferV2Cpi<'a, 'b> {
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));

--- a/clients/rust/src/generated/instructions/unverify_creator_v2.rs
+++ b/clients/rust/src/generated/instructions/unverify_creator_v2.rs
@@ -44,11 +44,11 @@ impl UnverifyCreatorV2 {
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(creator) = self.creator {
@@ -397,11 +397,11 @@ impl<'a, 'b> UnverifyCreatorV2Cpi<'a, 'b> {
         )],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));

--- a/clients/rust/src/generated/instructions/update_asset_data_v2.rs
+++ b/clients/rust/src/generated/instructions/update_asset_data_v2.rs
@@ -47,11 +47,11 @@ impl UpdateAssetDataV2 {
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(authority) = self.authority {
@@ -455,11 +455,11 @@ impl<'a, 'b> UpdateAssetDataV2Cpi<'a, 'b> {
         )],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));

--- a/clients/rust/src/generated/instructions/update_metadata_v2.rs
+++ b/clients/rust/src/generated/instructions/update_metadata_v2.rs
@@ -13,7 +13,7 @@ use borsh::BorshSerialize;
 /// Accounts.
 pub struct UpdateMetadataV2 {
     pub tree_config: solana_program::pubkey::Pubkey,
-    /// Optional payer, defaults to `authority`
+
     pub payer: solana_program::pubkey::Pubkey,
     /// Either collection authority or tree owner/delegate, depending
     /// on whether the item is in a verified collection.  Defaults to `payer`
@@ -48,11 +48,11 @@ impl UpdateMetadataV2 {
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(authority) = self.authority {
@@ -177,7 +177,6 @@ impl UpdateMetadataV2Builder {
         self.tree_config = Some(tree_config);
         self
     }
-    /// Optional payer, defaults to `authority`
     #[inline(always)]
     pub fn payer(&mut self, payer: solana_program::pubkey::Pubkey) -> &mut Self {
         self.payer = Some(payer);
@@ -336,7 +335,7 @@ impl UpdateMetadataV2Builder {
 /// `update_metadata_v2` CPI accounts.
 pub struct UpdateMetadataV2CpiAccounts<'a, 'b> {
     pub tree_config: &'b solana_program::account_info::AccountInfo<'a>,
-    /// Optional payer, defaults to `authority`
+
     pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Either collection authority or tree owner/delegate, depending
     /// on whether the item is in a verified collection.  Defaults to `payer`
@@ -363,7 +362,7 @@ pub struct UpdateMetadataV2Cpi<'a, 'b> {
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub tree_config: &'b solana_program::account_info::AccountInfo<'a>,
-    /// Optional payer, defaults to `authority`
+
     pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Either collection authority or tree owner/delegate, depending
     /// on whether the item is in a verified collection.  Defaults to `payer`
@@ -441,11 +440,11 @@ impl<'a, 'b> UpdateMetadataV2Cpi<'a, 'b> {
         )],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));
@@ -586,7 +585,6 @@ impl<'a, 'b> UpdateMetadataV2CpiBuilder<'a, 'b> {
         self.instruction.tree_config = Some(tree_config);
         self
     }
-    /// Optional payer, defaults to `authority`
     #[inline(always)]
     pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);

--- a/clients/rust/src/generated/instructions/verify_creator_v2.rs
+++ b/clients/rust/src/generated/instructions/verify_creator_v2.rs
@@ -44,11 +44,11 @@ impl VerifyCreatorV2 {
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.tree_config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.payer, true,
         ));
         if let Some(creator) = self.creator {
@@ -395,11 +395,11 @@ impl<'a, 'b> VerifyCreatorV2Cpi<'a, 'b> {
         )],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.tree_config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.payer.key,
             true,
         ));

--- a/idls/bubblegum.json
+++ b/idls/bubblegum.json
@@ -658,12 +658,12 @@
       "accounts": [
         {
           "name": "treeAuthority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -784,12 +784,12 @@
       "accounts": [
         {
           "name": "treeAuthority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -910,12 +910,12 @@
       "accounts": [
         {
           "name": "treeAuthority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -1551,12 +1551,12 @@
       "accounts": [
         {
           "name": "treeAuthority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -1741,12 +1741,12 @@
       "accounts": [
         {
           "name": "treeAuthority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -1896,12 +1896,12 @@
       "accounts": [
         {
           "name": "treeAuthority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -2013,12 +2013,12 @@
       "accounts": [
         {
           "name": "treeAuthority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -2221,7 +2221,7 @@
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -2579,12 +2579,12 @@
       "accounts": [
         {
           "name": "treeAuthority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -2682,12 +2682,12 @@
       "accounts": [
         {
           "name": "treeAuthority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {
@@ -2932,16 +2932,13 @@
       "accounts": [
         {
           "name": "treeAuthority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
           "name": "payer",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "Optional payer, defaults to `authority`"
-          ]
+          "isMut": true,
+          "isSigner": true
         },
         {
           "name": "authority",
@@ -3287,12 +3284,12 @@
       "accounts": [
         {
           "name": "treeAuthority",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
           "name": "payer",
-          "isMut": false,
+          "isMut": true,
           "isSigner": true
         },
         {

--- a/programs/bubblegum/program/src/processor/delegate.rs
+++ b/programs/bubblegum/program/src/processor/delegate.rs
@@ -96,10 +96,12 @@ pub(crate) fn delegate<'info>(
 #[derive(Accounts)]
 pub struct DelegateV2<'info> {
     #[account(
+        mut,
         seeds = [merkle_tree.key().as_ref()],
         bump,
     )]
     pub tree_authority: Account<'info, TreeConfig>,
+    #[account(mut)]
     pub payer: Signer<'info>,
     /// Optional leaf owner, defaults to `payer`
     pub leaf_owner: Option<Signer<'info>>,

--- a/programs/bubblegum/program/src/processor/delegate_and_freeze.rs
+++ b/programs/bubblegum/program/src/processor/delegate_and_freeze.rs
@@ -18,10 +18,12 @@ use crate::{
 #[derive(Accounts)]
 pub struct DelegateAndFreezeV2<'info> {
     #[account(
+        mut,
         seeds = [merkle_tree.key().as_ref()],
         bump,
     )]
     pub tree_authority: Account<'info, TreeConfig>,
+    #[account(mut)]
     pub payer: Signer<'info>,
     /// Optional leaf owner, defaults to `payer`
     pub leaf_owner: Option<Signer<'info>>,

--- a/programs/bubblegum/program/src/processor/freeze.rs
+++ b/programs/bubblegum/program/src/processor/freeze.rs
@@ -18,10 +18,12 @@ use crate::{
 #[derive(Accounts)]
 pub struct FreezeV2<'info> {
     #[account(
+        mut,
         seeds = [merkle_tree.key().as_ref()],
         bump,
     )]
     pub tree_authority: Account<'info, TreeConfig>,
+    #[account(mut)]
     pub payer: Signer<'info>,
     /// Optional authority, defaults to `payer`.  Must be either
     /// the leaf delegate or collection permanent freeze delegate.

--- a/programs/bubblegum/program/src/processor/set_collection.rs
+++ b/programs/bubblegum/program/src/processor/set_collection.rs
@@ -20,10 +20,12 @@ use crate::{
 #[derive(Accounts)]
 pub struct SetCollectionV2<'info> {
     #[account(
+        mut,
         seeds = [merkle_tree.key().as_ref()],
         bump,
     )]
     pub tree_authority: Account<'info, TreeConfig>,
+    #[account(mut)]
     pub payer: Signer<'info>,
     /// If item is not in a collection, then authority must be tree owner/delegate.  If item is
     /// getting removed from a collection, then this must be an authority for the existing

--- a/programs/bubblegum/program/src/processor/set_non_transferable.rs
+++ b/programs/bubblegum/program/src/processor/set_non_transferable.rs
@@ -18,10 +18,12 @@ use crate::{
 #[derive(Accounts)]
 pub struct SetNonTransferableV2<'info> {
     #[account(
+        mut,
         seeds = [merkle_tree.key().as_ref()],
         bump,
     )]
     pub tree_authority: Account<'info, TreeConfig>,
+    #[account(mut)]
     pub payer: Signer<'info>,
     /// This authority must be a permanent freeze delegate on the collection
     /// Defaults to `payer`

--- a/programs/bubblegum/program/src/processor/thaw_and_revoke.rs
+++ b/programs/bubblegum/program/src/processor/thaw_and_revoke.rs
@@ -16,10 +16,12 @@ use crate::{
 #[derive(Accounts)]
 pub struct ThawAndRevokeV2<'info> {
     #[account(
+        mut,
         seeds = [merkle_tree.key().as_ref()],
         bump,
     )]
     pub tree_authority: Account<'info, TreeConfig>,
+    #[account(mut)]
     pub payer: Signer<'info>,
     /// Optional leaf delegate, defaults to `payer`
     pub leaf_delegate: Option<Signer<'info>>,

--- a/programs/bubblegum/program/src/processor/transfer.rs
+++ b/programs/bubblegum/program/src/processor/transfer.rs
@@ -114,6 +114,7 @@ pub struct TransferV2<'info> {
         bump,
     )]
     pub tree_authority: Account<'info, TreeConfig>,
+    #[account(mut)]
     pub payer: Signer<'info>,
     /// Optional authority, defaults to `payer`.  Must be either
     /// the leaf owner or collection permanent transfer delegate.

--- a/programs/bubblegum/program/src/processor/update_asset_data.rs
+++ b/programs/bubblegum/program/src/processor/update_asset_data.rs
@@ -23,10 +23,12 @@ pub const MAX_ASSET_DATA_LEN: usize = 128;
 #[derive(Accounts)]
 pub struct UpdateAssetDataV2<'info> {
     #[account(
+        mut,
         seeds = [merkle_tree.key().as_ref()],
         bump,
     )]
     pub tree_authority: Account<'info, TreeConfig>,
+    #[account(mut)]
     pub payer: Signer<'info>,
     /// Either collection authority or tree owner/delegate, depending on
     /// whether the item is in a verified collection.  Defaults to `payer`

--- a/programs/bubblegum/program/src/processor/update_metadata.rs
+++ b/programs/bubblegum/program/src/processor/update_metadata.rs
@@ -142,11 +142,12 @@ pub fn update_metadata<'info>(
 #[derive(Accounts)]
 pub struct UpdateMetadataV2<'info> {
     #[account(
+        mut,
         seeds = [merkle_tree.key().as_ref()],
         bump,
     )]
     pub tree_authority: Account<'info, TreeConfig>,
-    /// Optional payer, defaults to `authority`
+    #[account(mut)]
     pub payer: Signer<'info>,
     /// Either collection authority or tree owner/delegate, depending
     /// on whether the item is in a verified collection.  Defaults to `payer`

--- a/programs/bubblegum/program/src/processor/verify_creator.rs
+++ b/programs/bubblegum/program/src/processor/verify_creator.rs
@@ -88,10 +88,12 @@ pub(crate) fn verify_creator<'info>(
 #[derive(Accounts)]
 pub struct CreatorVerificationV2<'info> {
     #[account(
+        mut,
         seeds = [merkle_tree.key().as_ref()],
         bump,
     )]
     pub tree_authority: Account<'info, TreeConfig>,
+    #[account(mut)]
     pub payer: Signer<'info>,
     /// Optional creator, defaults to `payer`
     pub creator: Option<Signer<'info>>,


### PR DESCRIPTION
### Notes
* Fix Merkle tree fetching in JS tests 
* Make payer accounts mutable in V2 instructions
* Add a few negative test cases
* Add transfer test with separate payer