### PR TITLE
Update txn parsers to work when Bubblegum ix is not first in the txn

### DIFF
--- a/clients/js/src/leafAssetId.ts
+++ b/clients/js/src/leafAssetId.ts
@@ -51,12 +51,38 @@ export async function parseLeafFromMintToCollectionV1Transaction(
   signature: TransactionSignature
 ): Promise<LeafSchema> {
   const transaction = await context.rpc.getTransaction(signature);
-  const innerInstructions = transaction?.meta.innerInstructions;
+  if (!transaction) {
+    throw new Error('Could not get transaction from signature');
+  }
 
+  const bubblegumProgramId = context.programs.getPublicKey(
+    'mplBubblegum',
+    MPL_BUBBLEGUM_PROGRAM_ID
+  );
+
+  // Find the outer instruction that invokes the Bubblegum program.
+  const instructionIndex = transaction.message.instructions.findIndex(
+    (ix) => transaction.message.accounts[ix.programIndex] === bubblegumProgramId
+  );
+
+  if (instructionIndex === -1) {
+    throw new Error('Could not find mplBubblegum instruction');
+  }
+
+  // Find the corresponding inner instruction group for that instruction index.
+  const innerInstructions = transaction.meta?.innerInstructions;
   if (innerInstructions) {
+    const inner = innerInstructions.find((ix) => ix.index === instructionIndex);
+
+    if (!inner || !inner.instructions[0]) {
+      throw new Error('Could not find matching inner instruction');
+    }
+
+    const instructionData = inner.instructions[0].data;
     const leaf = getLeafSchemaSerializer().deserialize(
-      innerInstructions[0].instructions[0].data.slice(8)
+      instructionData.slice(8) // Skip discriminator
     );
+
     return leaf[0];
   }
 
@@ -72,7 +98,29 @@ export async function parseLeafFromMintV2Transaction(
     throw new Error('Could not get transaction from signature');
   }
 
-  const instruction = transaction.message.instructions[0];
+  const bubblegumProgramId = context.programs.getPublicKey(
+    'mplBubblegum',
+    MPL_BUBBLEGUM_PROGRAM_ID
+  );
+
+  // Find the outer instruction that invokes the Bubblegum program.
+  const instructionIndex = transaction.message.instructions.findIndex(
+    (ix) => transaction.message.accounts[ix.programIndex] === bubblegumProgramId
+  );
+
+  if (instructionIndex === -1) {
+    throw new Error('Could not find mplBubblegum instruction');
+  }
+
+  const instruction = transaction.message.instructions[instructionIndex];
+
+  if (instruction.accountIndexes.length <= 7) {
+    throw new Error(
+      'Instruction does not have a collection account at index 7'
+    );
+  }
+
+  // Read the collection account from account index 7.
   const collectionIndex = instruction.accountIndexes[7];
   const collection = transaction.message.accounts[collectionIndex];
 
@@ -80,17 +128,24 @@ export async function parseLeafFromMintV2Transaction(
     throw new Error('Collection account at index 7 is missing');
   }
 
-  const programId = context.programs.getPublicKey(
-    'mplBubblegum',
-    MPL_BUBBLEGUM_PROGRAM_ID
-  );
+  // Use index 0 or 1 into the inner instructions depending on whether the collection is set to the
+  // Bubblegum program ID.
+  const innerInstructionIndex = collection === bubblegumProgramId ? 0 : 1;
 
-  const instructionIndex = collection === programId ? 0 : 1;
-  const { innerInstructions } = transaction.meta;
+  // Find the inner instruction group corresponding to the Bubblegum outer instruction.
+  const innerInstructions = transaction.meta?.innerInstructions;
   if (innerInstructions) {
+    const inner = innerInstructions.find((ix) => ix.index === instructionIndex);
+
+    if (!inner || !inner.instructions[innerInstructionIndex]) {
+      throw new Error('Could not find matching inner instruction');
+    }
+
+    const instructionData = inner.instructions[innerInstructionIndex].data;
     const leaf = getLeafSchemaSerializer().deserialize(
-      innerInstructions[0].instructions[instructionIndex].data.slice(8)
+      instructionData.slice(8) // Skip the 8-byte discriminator
     );
+
     return leaf[0];
   }
 


### PR DESCRIPTION
### Notes
* When parsing a Bubblegum instruction from a transaction, search for the instruction in the transaction where `programIndex` is the Bubblegum program ID.
* Use that to find the correct inner instruction group.
* Previous code assumed Bubblegum instruction was index 0.

### Testing
* Added tests.
* Also tested locally using a real devnet and mainnet transaction.