### PR TITLE
Add optional RpcGetTransactionOptions to parseLeaf functions

### DIFF
--- a/clients/js/src/leafAssetId.ts
+++ b/clients/js/src/leafAssetId.ts
@@ -2,6 +2,7 @@ import {
   Context,
   Pda,
   PublicKey,
+  RpcGetTransactionOptions,
   TransactionSignature,
 } from '@metaplex-foundation/umi';
 import { publicKey, string, u64 } from '@metaplex-foundation/umi/serializers';
@@ -31,9 +32,10 @@ export function findLeafAssetIdPda(
 
 export async function parseLeafFromMintV1Transaction(
   context: Pick<Context, 'programs' | 'eddsa' | 'rpc'>,
-  signature: TransactionSignature
+  signature: TransactionSignature,
+  options?: RpcGetTransactionOptions
 ): Promise<LeafSchema> {
-  const transaction = await context.rpc.getTransaction(signature);
+  const transaction = await context.rpc.getTransaction(signature, options);
   const innerInstructions = transaction?.meta.innerInstructions;
 
   if (innerInstructions) {
@@ -48,9 +50,10 @@ export async function parseLeafFromMintV1Transaction(
 
 export async function parseLeafFromMintToCollectionV1Transaction(
   context: Pick<Context, 'programs' | 'eddsa' | 'rpc'>,
-  signature: TransactionSignature
+  signature: TransactionSignature,
+  options?: RpcGetTransactionOptions
 ): Promise<LeafSchema> {
-  const transaction = await context.rpc.getTransaction(signature);
+  const transaction = await context.rpc.getTransaction(signature, options);
   if (!transaction) {
     throw new Error('Could not get transaction from signature');
   }
@@ -91,9 +94,10 @@ export async function parseLeafFromMintToCollectionV1Transaction(
 
 export async function parseLeafFromMintV2Transaction(
   context: Pick<Context, 'programs' | 'eddsa' | 'rpc'>,
-  signature: TransactionSignature
+  signature: TransactionSignature,
+  options?: RpcGetTransactionOptions
 ): Promise<LeafSchema> {
-  const transaction = await context.rpc.getTransaction(signature);
+  const transaction = await context.rpc.getTransaction(signature, options);
   if (!transaction) {
     throw new Error('Could not get transaction from signature');
   }


### PR DESCRIPTION
## Summary

- Add an optional `options?: RpcGetTransactionOptions` parameter to all three `parseLeaf` functions:
  - `parseLeafFromMintV1Transaction`
  - `parseLeafFromMintToCollectionV1Transaction`
  - `parseLeafFromMintV2Transaction`
- Pass `options` through to `context.rpc.getTransaction(signature, options)`

## Motivation

When using `sendAndConfirm` with `{ commitment: "confirmed" }` for faster UX, the subsequent `parseLeaf` call fails because `getTransaction` defaults to `finalized` commitment — the transaction exists at `confirmed` but isn't visible at `finalized` yet.

This forces consumers to inline the entire leaf-parsing logic just to pass `{ commitment: "confirmed" }` to `getTransaction`. The `RpcInterface` already supports `RpcGetTransactionOptions` (which extends `RpcBaseOptions` with `commitment`), so the fix is simply passing it through.

## Example usage

```typescript
const { signature } = await mintToCollectionV1(umi, { ... })
  .sendAndConfirm(umi, { confirm: { commitment: "confirmed" } });

const leaf = await parseLeafFromMintToCollectionV1Transaction(
  umi,
  signature,
  { commitment: "confirmed" }
);
```

## Breaking changes

None. The new parameter is optional — existing callers are unaffected.