### PR TITLE
Allow inner instruction parsing with parseLeafFromMintV2Transaction

### DIFF
--- a/clients/js/src/leafAssetId.ts
+++ b/clients/js/src/leafAssetId.ts
@@ -108,45 +108,50 @@ export async function parseLeafFromMintV2Transaction(
     (ix) => transaction.message.accounts[ix.programIndex] === bubblegumProgramId
   );
 
-  if (instructionIndex === -1) {
-    throw new Error('Could not find mplBubblegum instruction');
-  }
-
-  const instruction = transaction.message.instructions[instructionIndex];
-
-  if (instruction.accountIndexes.length <= 7) {
-    throw new Error(
-      'Instruction does not have a collection account at index 7'
-    );
-  }
-
-  // Read the collection account from account index 7.
-  const collectionIndex = instruction.accountIndexes[7];
-  const collection = transaction.message.accounts[collectionIndex];
-
-  if (!collection) {
-    throw new Error('Collection account at index 7 is missing');
-  }
-
-  // Use index 0 or 1 into the inner instructions depending on whether the collection is set to the
-  // Bubblegum program ID.
-  const innerInstructionIndex = collection === bubblegumProgramId ? 0 : 1;
-
-  // Find the inner instruction group corresponding to the Bubblegum outer instruction.
   const innerInstructions = transaction.meta?.innerInstructions;
-  if (innerInstructions) {
-    const inner = innerInstructions.find((ix) => ix.index === instructionIndex);
 
-    if (!inner || !inner.instructions[innerInstructionIndex]) {
-      throw new Error('Could not find matching inner instruction');
+  // Direct path: bubblegum is a top-level instruction
+  if (instructionIndex !== -1 && innerInstructions) {
+    const instruction = transaction.message.instructions[instructionIndex];
+
+    if (instruction.accountIndexes.length > 7) {
+      const collectionIndex = instruction.accountIndexes[7];
+      const collection = transaction.message.accounts[collectionIndex];
+
+      if (collection) {
+        const innerInstructionIndex = collection === bubblegumProgramId ? 0 : 1;
+        const inner = innerInstructions.find((ix) => ix.index === instructionIndex);
+
+        if (inner?.instructions[innerInstructionIndex]) {
+          const leaf = getLeafSchemaSerializer().deserialize(
+            inner.instructions[innerInstructionIndex].data.slice(8)
+          );
+          return leaf[0];
+        }
+      }
     }
+  }
 
-    const instructionData = inner.instructions[innerInstructionIndex].data;
-    const leaf = getLeafSchemaSerializer().deserialize(
-      instructionData.slice(8) // Skip the 8-byte discriminator
-    );
+  // Fallback: bubblegum was called via CPI (e.g., mpl-core execute).
+  // Scan all inner instructions for leaf schema data.
+  if (innerInstructions) {
+    const allInnerIxs = innerInstructions.flatMap((group) => group.instructions);
+    const leafIx = allInnerIxs.find((ix) => {
+      try {
+        if (ix.data.length >= 9) {
+          getLeafSchemaSerializer().deserialize(ix.data.slice(8));
+          return true;
+        }
+      } catch {
+        // Not a leaf instruction
+      }
+      return false;
+    });
 
-    return leaf[0];
+    if (leafIx) {
+      const [leaf] = getLeafSchemaSerializer().deserialize(leafIx.data.slice(8));
+      return leaf;
+    }
   }
 
   throw new Error('Could not parse leaf from transaction');

--- a/clients/js/src/leafAssetId.ts
+++ b/clients/js/src/leafAssetId.ts
@@ -120,7 +120,9 @@ export async function parseLeafFromMintV2Transaction(
 
       if (collection) {
         const innerInstructionIndex = collection === bubblegumProgramId ? 0 : 1;
-        const inner = innerInstructions.find((ix) => ix.index === instructionIndex);
+        const inner = innerInstructions.find(
+          (ix) => ix.index === instructionIndex
+        );
 
         if (inner?.instructions[innerInstructionIndex]) {
           const leaf = getLeafSchemaSerializer().deserialize(
@@ -135,7 +137,9 @@ export async function parseLeafFromMintV2Transaction(
   // Fallback: bubblegum was called via CPI (e.g., mpl-core execute).
   // Scan all inner instructions for leaf schema data.
   if (innerInstructions) {
-    const allInnerIxs = innerInstructions.flatMap((group) => group.instructions);
+    const allInnerIxs = innerInstructions.flatMap(
+      (group) => group.instructions
+    );
     const leafIx = allInnerIxs.find((ix) => {
       try {
         if (ix.data.length >= 9) {
@@ -149,7 +153,9 @@ export async function parseLeafFromMintV2Transaction(
     });
 
     if (leafIx) {
-      const [leaf] = getLeafSchemaSerializer().deserialize(leafIx.data.slice(8));
+      const [leaf] = getLeafSchemaSerializer().deserialize(
+        leafIx.data.slice(8)
+      );
       return leaf;
     }
   }

--- a/clients/js/test/parseMintV2.test.ts
+++ b/clients/js/test/parseMintV2.test.ts
@@ -1,8 +1,15 @@
 /* eslint-disable no-await-in-loop */
-import { createCollection } from '@metaplex-foundation/mpl-core';
 import {
+  create,
+  createCollection,
+  execute,
+  findAssetSignerPda,
+} from '@metaplex-foundation/mpl-core';
+import {
+  createNoopSigner,
   defaultPublicKey,
   generateSigner,
+  publicKey,
   some,
   none,
 } from '@metaplex-foundation/umi';
@@ -150,6 +157,54 @@ test('it can parse the leaf schema from mintV2 when Bubblegum instruction is not
     .add(mintBuilder)
     .sendAndConfirm(umi);
 
+  const leaf = await parseLeafFromMintV2Transaction(umi, signature);
+  const assetId = findLeafAssetIdPda(umi, { merkleTree, leafIndex: 0 });
+
+  t.is(leafOwner, leaf.owner);
+  t.is(Number(leaf.nonce), 0);
+  t.is(leaf.id, assetId[0]);
+});
+
+test('it can parse the leaf from mintV2 called via mpl-core execute (CPI)', async (t) => {
+  // Given an empty Bubblegum tree.
+  const umi = await createUmi();
+  const merkleTree = await createTreeV2(umi);
+  const leafOwner = generateSigner(umi).publicKey;
+
+  // And a Core asset to use with execute.
+  const asset = generateSigner(umi);
+  await create(umi, {
+    asset,
+    name: 'Test Asset',
+    uri: 'https://example.com/asset.json',
+  }).sendAndConfirm(umi);
+
+  // When we mint a new NFT via mpl-core execute (CPI into Bubblegum).
+  const metadata: MetadataArgsV2Args = {
+    name: 'My NFT',
+    uri: 'https://example.com/my-nft.json',
+    sellerFeeBasisPoints: 500, // 5%
+    collection: none(),
+    creators: [],
+  };
+
+  const assetSignerPda = findAssetSignerPda(umi, {
+    asset: asset.publicKey,
+  });
+
+  const mintBuilder = mintV2(umi, {
+    leafOwner,
+    merkleTree,
+    metadata,
+  });
+
+  const { signature } = await execute(umi, {
+    asset,
+    instructions: mintBuilder,
+    signers: [createNoopSigner(publicKey(assetSignerPda))],
+  }).sendAndConfirm(umi);
+
+  // Then the leaf can be parsed from the CPI transaction.
   const leaf = await parseLeafFromMintV2Transaction(umi, signature);
   const assetId = findLeafAssetIdPda(umi, { merkleTree, leafIndex: 0 });
 


### PR DESCRIPTION
The current parseLeafFromMintV2Transaction cannot find the leaf id, if the mint is happening in a CPI (e.g. core execute).
With this change, if there is no top level mintV2 ix we are also checking inner instructions and parse the asset address