### PR TITLE
fix: re-export generated mintV2 helpers from package root

### DIFF
--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -10,4 +10,4 @@ export * from './merkle';
 export * from './plugin';
 export * from './canTransfer';
 export * from './getCompressionProgramsForV1Ixs';
-export { mintV2 } from './mintV2';
+export * from './mintV2';

--- a/clients/js/src/mintV2.ts
+++ b/clients/js/src/mintV2.ts
@@ -7,6 +7,18 @@ import {
 } from './generated/instructions/mintV2';
 import { SELLER_FEE_BASIS_POINTS_INHERIT } from './hash';
 
+// Re-export the generated mintV2 helpers that are no longer star-exported
+// from ./generated/instructions since this wrapper replaced the generated
+// mintV2 function. Note the generated MintV2InstructionArgs is intentionally
+// superseded by the widened type below, which makes sellerFeeBasisPoints
+// optional when a core collection is provided.
+export {
+  getMintV2InstructionDataSerializer,
+  type MintV2InstructionAccounts,
+  type MintV2InstructionData,
+  type MintV2InstructionDataArgs,
+} from './generated/instructions/mintV2';
+
 export type MintV2InstructionArgs = Omit<
   GeneratedMintV2InstructionArgs,
   'metadata'


### PR DESCRIPTION
## Summary

#170 replaced the generated `mintV2` function with a hand-written wrapper that makes `metadata.sellerFeeBasisPoints` optional when a `coreCollection` is provided (defaulting to the inherit sentinel). As part of that change, `src/generated/instructions/index.ts` stopped star-exporting the generated `mintV2` module, and the package root only re-exported the wrapper function itself.

This unintentionally removed the following previously-public exports from the package root:

- `MintV2InstructionAccounts`
- `MintV2InstructionData`
- `MintV2InstructionDataArgs`
- `MintV2InstructionArgs`
- `getMintV2InstructionDataSerializer`

Any consumer importing these (e.g. indexers deserializing `mintV2` instructions via the serializer, or apps typing their mint parameters) would hit compile errors on upgrade, making an otherwise additive release a breaking one.

## Changes

- `src/mintV2.ts` re-exports `getMintV2InstructionDataSerializer`, `MintV2InstructionAccounts`, `MintV2InstructionData`, and `MintV2InstructionDataArgs` from the generated module.
- `src/index.ts` star-exports `./mintV2` instead of only exporting the `mintV2` function, so the re-exports above and the wrapper's `MintV2InstructionArgs` type are all available from the package root again.

Note: `MintV2InstructionArgs` intentionally resolves to the wrapper's widened type (with optional `sellerFeeBasisPoints`) rather than the generated one. It accepts a superset of the generated type, so existing usage still compiles.

## Testing

- `pnpm build` succeeds; verified `mintV2` and `getMintV2InstructionDataSerializer` are present in the built `dist/src/index.js` and all four types appear in the emitted declarations reachable from the root.
- `pnpm lint` passes.

Made with [Cursor](https://cursor.com)