### PR TITLE
Align getAssetWithProof with DAS inherited SFBP _raw fields

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -25,7 +25,7 @@
   "author": "Metaplex Maintainers <contact@metaplex.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@metaplex-foundation/digital-asset-standard-api": "^2.1.0",
+    "@metaplex-foundation/digital-asset-standard-api": "^2.1.1",
     "@metaplex-foundation/mpl-account-compression": "^0.0.1",
     "@metaplex-foundation/mpl-token-metadata": "3.2.1",
     "@metaplex-foundation/mpl-toolbox": "^0.10.0",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -25,7 +25,7 @@
   "author": "Metaplex Maintainers <contact@metaplex.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@metaplex-foundation/digital-asset-standard-api": "^2.0.0",
+    "@metaplex-foundation/digital-asset-standard-api": "^2.1.0",
     "@metaplex-foundation/mpl-account-compression": "^0.0.1",
     "@metaplex-foundation/mpl-token-metadata": "3.2.1",
     "@metaplex-foundation/mpl-toolbox": "^0.10.0",

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@metaplex-foundation/digital-asset-standard-api':
-    specifier: ^2.0.0
-    version: 2.0.0(@metaplex-foundation/umi@1.2.0)
+    specifier: ^2.1.1
+    version: 2.1.1(@metaplex-foundation/umi@1.2.0)
   '@metaplex-foundation/mpl-account-compression':
     specifier: ^0.0.1
     version: 0.0.1(@metaplex-foundation/umi@1.2.0)
@@ -290,8 +290,8 @@ packages:
       '@metaplex-foundation/umi': 1.2.0
     dev: false
 
-  /@metaplex-foundation/digital-asset-standard-api@2.0.0(@metaplex-foundation/umi@1.2.0):
-    resolution: {integrity: sha512-CnFN7epCwNcei+OzDvIg7KpTcB+O827YKomdjKEl72LF/DHfDMXqpbnXf2qsIF4iGaBEOviwxkjUwbXIDLpAxQ==}
+  /@metaplex-foundation/digital-asset-standard-api@2.1.1(@metaplex-foundation/umi@1.2.0):
+    resolution: {integrity: sha512-Kr/gfN6q6vMDCXEuJljcuk48d1vgm4VSm6FdADaYHhVhcJ0QhTgdiy0StnCN9rAQPE1ciWbrE7B6nBnMEebY3g==}
     peerDependencies:
       '@metaplex-foundation/umi': '>= 0.8.2 <= 1'
     dependencies:

--- a/clients/js/src/getAssetWithProof.ts
+++ b/clients/js/src/getAssetWithProof.ts
@@ -111,7 +111,10 @@ export const getAssetWithProof = async (
     : none();
 
   const { royalty } = rpcAsset;
-  const inherited = royalty ? isInheritedSfbpRoyalty(royalty) : false;
+  const inherited = royalty
+    ? isInheritedSfbpRoyalty(royalty) ||
+      royalty.basis_points === SELLER_FEE_BASIS_POINTS_INHERIT
+    : false;
 
   // Main / display fields (DAS `basis_points`, `creators`).
   const sellerFeeBasisPoints = royalty?.basis_points ?? 0;

--- a/clients/js/src/getAssetWithProof.ts
+++ b/clients/js/src/getAssetWithProof.ts
@@ -1,5 +1,6 @@
 import {
   Context,
+  Option,
   PublicKey,
   none,
   publicKey,
@@ -11,62 +12,19 @@ import {
   DasApiAsset,
   DasApiInterface,
   GetAssetProofRpcResponse,
+  isInheritedSfbpRoyalty,
+  SELLER_FEE_BASIS_POINTS_INHERIT,
 } from '@metaplex-foundation/digital-asset-standard-api';
 import { fetchMerkleTree } from '@metaplex-foundation/spl-account-compression';
 import { LeafSchemaV2Flags, isValidLeafSchemaV2Flags } from './flags';
 import {
+  Collection,
+  Creator,
   MetadataArgs,
   MetadataArgsV2Args,
   TokenProgramVersion,
   TokenStandard,
 } from './generated';
-import { SELLER_FEE_BASIS_POINTS_INHERIT, hashMetadataDataV2 } from './hash';
-
-/**
- * DasRoyaltyWithRawSfbp carries optional DAS-extension hints that are not part
- * of the official DAS schema. The basis_points_raw field preserves the raw
- * seller fee basis points used in the leaf hash, and sfbp_inherited indicates
- * inherited seller-fee-by-proxy. These fields may be present when a client
- * augments DAS responses with inferred or inherited royalty data.
- */
-type DasRoyaltyWithRawSfbp = NonNullable<DasApiAsset['royalty']> & {
-  basis_points_raw?: number;
-  sfbp_inherited?: boolean;
-};
-
-/**
- * DasApiAssetWithRawSfbp is a DAS asset whose royalty object may include the
- * optional DAS-extension fields basis_points_raw and sfbp_inherited, usually
- * added when the client augments DAS responses with inferred or inherited
- * royalty data.
- */
-type DasApiAssetWithRawSfbp = DasApiAsset & {
-  royalty?: DasRoyaltyWithRawSfbp;
-};
-
-const bytesEqual = (a: Uint8Array, b: Uint8Array): boolean =>
-  a.length === b.length && a.every((value, index) => value === b[index]);
-
-const bytesToBase58 = (bytes: Uint8Array): string =>
-  publicKey(bytes).toString();
-
-const hasDasRoyaltyWithRawSfbp = (
-  asset: DasApiAsset
-): asset is DasApiAssetWithRawSfbp => {
-  const { royalty } = asset;
-  if (!royalty || typeof royalty !== 'object') {
-    return false;
-  }
-
-  const hasBasisPointsRaw = 'basis_points_raw' in royalty;
-  const hasSfbpInherited = 'sfbp_inherited' in royalty;
-
-  return (
-    (hasBasisPointsRaw || hasSfbpInherited) &&
-    (!hasBasisPointsRaw || typeof royalty.basis_points_raw === 'number') &&
-    (!hasSfbpInherited || typeof royalty.sfbp_inherited === 'boolean')
-  );
-};
 
 export type AssetWithProof = {
   leafOwner: PublicKey;
@@ -81,19 +39,37 @@ export type AssetWithProof = {
   nonce: number;
   index: number;
   proof: PublicKey[];
+  /**
+   * Display-aligned metadata mirroring DAS main fields
+   * (`royalty.basis_points`, `creators`). Type stays `MetadataArgs`.
+   * When SFBP is inherited this holds the collection-resolved rate and payees.
+   */
   metadata: MetadataArgs;
-  /** Canonical on-chain metadata for V2 hash/update instructions. Omitted for V1 assets. */
-  currentMetadata?: MetadataArgsV2Args;
+  /**
+   * Canonical leaf metadata for V2 hash and write instructions.
+   * Uses DAS `_raw` royalty fields when royalties are inherited.
+   */
+  currentMetadata: MetadataArgsV2Args;
+  /**
+   * Leaf SFBP from DAS `royalty.basis_points_raw`. Set only when DAS provides
+   * `_raw` / inherited SFBP (omitted for ordinary assets, like DAS).
+   */
+  sellerFeeBasisPointsRaw?: number;
+  /**
+   * Leaf creators from DAS `creators_raw`. Set only when DAS provides
+   * `creators_raw` / inherited SFBP (omitted for ordinary assets, like DAS).
+   */
+  creatorsRaw?: Array<Creator>;
+  /**
+   * Sugar for `rpcAsset.royalty.inherited` / inherit-sentinel detection.
+   */
+  inherited: boolean;
   rpcAsset: DasApiAsset;
   rpcAssetProof: GetAssetProofRpcResponse;
 };
 
 type GetAssetWithProofOptions = {
   truncateCanopy?: boolean;
-  resolveCollectionSellerFeeBasisPoints?: (
-    collection: PublicKey,
-    rpcAsset: DasApiAsset
-  ) => number | Promise<number | undefined> | undefined;
 };
 
 export const getAssetWithProof = async (
@@ -108,9 +84,6 @@ export const getAssetWithProof = async (
     }),
     context.rpc.getAssetProof(assetId),
   ]);
-  const rpcAssetWithRawSfbp = hasDasRoyaltyWithRawSfbp(rpcAsset)
-    ? rpcAsset
-    : undefined;
 
   let { proof } = rpcAssetProof;
   if (options?.truncateCanopy) {
@@ -126,101 +99,66 @@ export const getAssetWithProof = async (
   }
 
   const collectionGroup = (rpcAsset.grouping ?? []).find(
-    (group) => group.group_key === 'collection'
+    (group) => group.group_key === 'collection' && group.group_value != null
   );
-  const collection = collectionGroup
-    ? {
-        key: publicKey(collectionGroup.group_value),
+
+  const collection: Option<Collection> = collectionGroup
+    ? some({
+        key: publicKey(collectionGroup.group_value as string),
         verified: collectionGroup.verified ?? false,
-      }
-    : undefined;
+      })
+    : none();
 
-  const rawSellerFeeBasisPoints =
-    rpcAssetWithRawSfbp?.royalty?.basis_points_raw ??
-    (rpcAssetWithRawSfbp?.royalty?.sfbp_inherited
-      ? SELLER_FEE_BASIS_POINTS_INHERIT
-      : rpcAsset.royalty?.basis_points);
-  const sellerFeeBasisPointsInherited =
-    rpcAssetWithRawSfbp?.royalty?.sfbp_inherited ??
-    rawSellerFeeBasisPoints === SELLER_FEE_BASIS_POINTS_INHERIT;
-  let resolvedSellerFeeBasisPoints = rpcAsset.royalty?.basis_points;
+  const { royalty } = rpcAsset;
+  const inherited = royalty ? isInheritedSfbpRoyalty(royalty) : false;
 
-  // Preserve the raw sentinel for currentMetadata/hash comparisons, while the
-  // display metadata prefers the resolved value returned by DAS or the optional
-  // collection resolver.
-  if (
-    sellerFeeBasisPointsInherited &&
-    resolvedSellerFeeBasisPoints === SELLER_FEE_BASIS_POINTS_INHERIT &&
-    collection &&
-    options?.resolveCollectionSellerFeeBasisPoints
-  ) {
-    resolvedSellerFeeBasisPoints =
-      (await options.resolveCollectionSellerFeeBasisPoints(
-        collection.key,
-        rpcAsset
-      )) ?? resolvedSellerFeeBasisPoints;
+  // Main / display fields (DAS `basis_points`, `creators`).
+  const sellerFeeBasisPoints = royalty?.basis_points ?? 0;
+  const { creators } = rpcAsset;
+
+  // Leaf `_raw` — only when DAS exposes them or SFBP is inherited (DAS omission).
+  let sellerFeeBasisPointsRaw: number | undefined;
+  let creatorsRaw: Array<Creator> | undefined;
+  if (royalty?.basis_points_raw != null) {
+    sellerFeeBasisPointsRaw = royalty.basis_points_raw;
+  } else if (inherited) {
+    sellerFeeBasisPointsRaw = SELLER_FEE_BASIS_POINTS_INHERIT;
+  }
+  if (rpcAsset.creators_raw != null) {
+    creatorsRaw = rpcAsset.creators_raw;
+  } else if (inherited) {
+    creatorsRaw = [];
   }
 
   const metadata: MetadataArgs = {
     name: rpcAsset.content?.metadata?.name ?? '',
     symbol: rpcAsset.content?.metadata?.symbol ?? '',
     uri: rpcAsset.content?.json_uri,
-    sellerFeeBasisPoints:
-      resolvedSellerFeeBasisPoints ?? rawSellerFeeBasisPoints,
-    primarySaleHappened: rpcAsset.royalty?.primary_sale_happened,
+    sellerFeeBasisPoints,
+    primarySaleHappened: royalty?.primary_sale_happened,
     isMutable: rpcAsset.mutable,
     editionNonce: wrapNullable(rpcAsset.supply?.edition_nonce),
     tokenStandard: some(TokenStandard.NonFungible),
-    collection: collection ? some(collection) : none(),
+    collection,
     uses: none(),
     tokenProgramVersion: TokenProgramVersion.Original,
-    creators: rpcAsset.creators,
+    creators,
   };
-  const buildCurrentMetadata = (
-    sellerFeeBasisPoints: number
-  ): MetadataArgsV2Args => ({
+
+  const currentMetadata: MetadataArgsV2Args = {
     name: metadata.name,
     symbol: metadata.symbol,
     uri: metadata.uri,
-    sellerFeeBasisPoints,
+    sellerFeeBasisPoints:
+      sellerFeeBasisPointsRaw ?? metadata.sellerFeeBasisPoints,
     primarySaleHappened: metadata.primarySaleHappened,
     isMutable: metadata.isMutable,
     tokenStandard: metadata.tokenStandard,
-    creators: metadata.creators,
-    collection: collection ? some(collection.key) : none(),
-  });
-
-  const expectedDataHash = publicKeyBytes(rpcAsset.compression.data_hash);
-  let currentMetadata = buildCurrentMetadata(
-    rawSellerFeeBasisPoints ?? resolvedSellerFeeBasisPoints
-  );
-  const isV2Compression =
-    rpcAsset.compression.collection_hash !== undefined ||
-    rpcAsset.compression.asset_data_hash !== undefined ||
-    rpcAsset.compression.flags !== undefined;
-  if (isV2Compression && collection) {
-    const currentMetadataHash = hashMetadataDataV2(currentMetadata);
-    if (!bytesEqual(currentMetadataHash, expectedDataHash)) {
-      const inheritedMetadata = buildCurrentMetadata(
-        SELLER_FEE_BASIS_POINTS_INHERIT
-      );
-      const inheritedMetadataHash = hashMetadataDataV2(inheritedMetadata);
-      if (bytesEqual(inheritedMetadataHash, expectedDataHash)) {
-        currentMetadata = inheritedMetadata;
-      } else {
-        throw new Error(
-          [
-            'Unable to reconstruct current metadata data hash from DAS asset.',
-            `expectedDataHash=${bytesToBase58(expectedDataHash)}`,
-            `currentMetadataHash=${bytesToBase58(currentMetadataHash)}`,
-            `currentSellerFeeBasisPoints=${currentMetadata.sellerFeeBasisPoints}`,
-            `inheritedMetadataHash=${bytesToBase58(inheritedMetadataHash)}`,
-            `inheritedSellerFeeBasisPoints=${inheritedMetadata.sellerFeeBasisPoints}`,
-          ].join(' ')
-        );
-      }
-    }
-  }
+    creators: creatorsRaw ?? metadata.creators,
+    collection: collectionGroup
+      ? some(publicKey(collectionGroup.group_value as string))
+      : none(),
+  };
 
   const collectionHashBytes = rpcAsset.compression.collection_hash
     ? publicKeyBytes(rpcAsset.compression.collection_hash)
@@ -241,7 +179,7 @@ export const getAssetWithProof = async (
       : rpcAsset.ownership.owner,
     merkleTree: rpcAssetProof.tree_id,
     root: publicKeyBytes(rpcAssetProof.root),
-    dataHash: expectedDataHash,
+    dataHash: publicKeyBytes(rpcAsset.compression.data_hash),
     creatorHash: publicKeyBytes(rpcAsset.compression.creator_hash),
     collection_hash: collectionHashBytes,
     asset_data_hash: assetDataHashBytes,
@@ -251,6 +189,9 @@ export const getAssetWithProof = async (
     proof,
     metadata,
     currentMetadata,
+    sellerFeeBasisPointsRaw,
+    creatorsRaw,
+    inherited,
     rpcAsset,
     rpcAssetProof,
   };

--- a/clients/js/src/getAssetWithProof.ts
+++ b/clients/js/src/getAssetWithProof.ts
@@ -25,6 +25,7 @@ import {
   TokenProgramVersion,
   TokenStandard,
 } from './generated';
+import { asCurrentMetadataV2 } from './leafMetadata';
 
 export type AssetWithProof = {
   leafOwner: PublicKey;
@@ -145,20 +146,11 @@ export const getAssetWithProof = async (
     creators,
   };
 
-  const currentMetadata: MetadataArgsV2Args = {
-    name: metadata.name,
-    symbol: metadata.symbol,
-    uri: metadata.uri,
-    sellerFeeBasisPoints:
-      sellerFeeBasisPointsRaw ?? metadata.sellerFeeBasisPoints,
-    primarySaleHappened: metadata.primarySaleHappened,
-    isMutable: metadata.isMutable,
-    tokenStandard: metadata.tokenStandard,
-    creators: creatorsRaw ?? metadata.creators,
-    collection: collectionGroup
-      ? some(publicKey(collectionGroup.group_value as string))
-      : none(),
-  };
+  const currentMetadata = asCurrentMetadataV2({
+    metadata,
+    sellerFeeBasisPointsRaw,
+    creatorsRaw,
+  });
 
   const collectionHashBytes = rpcAsset.compression.collection_hash
     ? publicKeyBytes(rpcAsset.compression.collection_hash)

--- a/clients/js/src/getAssetWithProof.ts
+++ b/clients/js/src/getAssetWithProof.ts
@@ -15,7 +15,12 @@ import {
   isInheritedSfbpRoyalty,
   SELLER_FEE_BASIS_POINTS_INHERIT,
 } from '@metaplex-foundation/digital-asset-standard-api';
-import { fetchMerkleTree } from '@metaplex-foundation/spl-account-compression';
+import {
+  fetchMerkleTree,
+  getConcurrentMerkleTreeHeaderSerializer,
+  getMerkleTreeSize,
+} from '@metaplex-foundation/spl-account-compression';
+import { base64 } from '@metaplex-foundation/umi/serializers';
 import { LeafSchemaV2Flags, isValidLeafSchemaV2Flags } from './flags';
 import {
   Collection,
@@ -73,6 +78,67 @@ type GetAssetWithProofOptions = {
   truncateCanopy?: boolean;
 };
 
+type GetAccountInfoResult = {
+  value?: {
+    data?: [string, string];
+    space?: number;
+  } | null;
+};
+
+const MERKLE_TREE_HEADER_SIZE =
+  getConcurrentMerkleTreeHeaderSerializer().fixedSize ?? 56;
+
+/** Canopy nodes occupy 32 * ((1 << (depth + 1)) - 2) bytes after the tree body. */
+const canopyDepthFromNodeCount = (canopyNodes: number): number | null => {
+  if (canopyNodes <= 0) return 0;
+  const canopyDepth = Math.log2(canopyNodes + 2) - 1;
+  return Number.isInteger(canopyDepth) && canopyDepth >= 0 ? canopyDepth : null;
+};
+
+/**
+ * Resolve canopy depth without downloading the full merkle tree account.
+ * Tree accounts with a canopy are large enough that `getAccountInfo` often
+ * socket-timeouts on DAS / public RPCs (and on CI).
+ */
+const getCanopyDepth = async (
+  context: Pick<Context, 'rpc'>,
+  merkleTree: PublicKey
+): Promise<number> => {
+  try {
+    const result = await context.rpc.call<GetAccountInfoResult>(
+      'getAccountInfo',
+      [
+        merkleTree,
+        {
+          encoding: 'base64',
+          dataSlice: { offset: 0, length: MERKLE_TREE_HEADER_SIZE },
+        },
+      ]
+    );
+    const value = result?.value;
+    if (value?.data?.[0] != null && value.space != null) {
+      const headerBytes = base64.serialize(value.data[0]);
+      const [{ header }] =
+        getConcurrentMerkleTreeHeaderSerializer().deserialize(headerBytes);
+      if (header.__kind === 'V1') {
+        const sizeWithoutCanopy = getMerkleTreeSize(
+          header.maxDepth,
+          header.maxBufferSize,
+          0
+        );
+        const canopyNodes = (value.space - sizeWithoutCanopy) / 32;
+        const canopyDepth = canopyDepthFromNodeCount(canopyNodes);
+        if (canopyDepth != null) return canopyDepth;
+      }
+    }
+  } catch {
+    // Fall back to a full account fetch if the sliced RPC path is unavailable.
+  }
+
+  const merkleTreeAccount = await fetchMerkleTree(context, merkleTree);
+  return canopyDepthFromNodeCount(merkleTreeAccount.canopy.length) ?? 0;
+};
+
 export const getAssetWithProof = async (
   context: Pick<Context, 'rpc'> & { rpc: DasApiInterface },
   assetId: PublicKey,
@@ -88,11 +154,7 @@ export const getAssetWithProof = async (
 
   let { proof } = rpcAssetProof;
   if (options?.truncateCanopy) {
-    const merkleTreeAccount = await fetchMerkleTree(
-      context,
-      rpcAssetProof.tree_id
-    );
-    const canopyDepth = Math.log2(merkleTreeAccount.canopy.length + 2) - 1;
+    const canopyDepth = await getCanopyDepth(context, rpcAssetProof.tree_id);
     proof = rpcAssetProof.proof.slice(
       0,
       canopyDepth === 0 ? undefined : -canopyDepth

--- a/clients/js/src/hash.ts
+++ b/clients/js/src/hash.ts
@@ -16,6 +16,7 @@ import {
 } from '@metaplex-foundation/umi/serializers';
 import { keccak_256 } from '@noble/hashes/sha3';
 import {
+  Creator,
   MetadataArgsArgs,
   MetadataArgsV2Args,
   getCreatorSerializer,
@@ -24,12 +25,19 @@ import {
 } from './generated';
 import { findLeafAssetIdPda } from './leafAssetId';
 import { LeafSchemaV2Flags, isValidLeafSchemaV2Flags } from './flags';
+import {
+  RoyaltyRawFields,
+  toLeafMetadata,
+  toLeafMetadataV2,
+} from './leafMetadata';
 
 export const SELLER_FEE_BASIS_POINTS_INHERIT = 0xffff;
 
 export function hash(input: Uint8Array | Uint8Array[]): Uint8Array {
   return keccak_256(Array.isArray(input) ? mergeBytes(input) : input);
 }
+
+type V2OrV1Metadata = MetadataArgsV2Args | MetadataArgsArgs;
 
 export function hashLeaf(
   context: Pick<Context, 'eddsa' | 'programs'>,
@@ -39,6 +47,8 @@ export function hashLeaf(
     delegate?: PublicKey;
     leafIndex: number | bigint;
     metadata: MetadataArgsArgs;
+    sellerFeeBasisPointsRaw?: number;
+    creatorsRaw?: Array<Creator>;
     nftVersion?: number;
   }
 ): Uint8Array {
@@ -48,6 +58,10 @@ export function hashLeaf(
     merkleTree: input.merkleTree,
     leafIndex: input.leafIndex,
   });
+  const metadata = toLeafMetadata(input.metadata, {
+    sellerFeeBasisPointsRaw: input.sellerFeeBasisPointsRaw,
+    creatorsRaw: input.creatorsRaw,
+  });
 
   return hash([
     u8().serialize(nftVersion),
@@ -55,22 +69,33 @@ export function hashLeaf(
     publicKeySerializer().serialize(input.owner),
     publicKeySerializer().serialize(delegate),
     u64().serialize(input.leafIndex),
-    hashMetadata(input.metadata),
+    hashMetadata(metadata),
   ]);
 }
 
+type HashLeafV2Input = {
+  merkleTree: PublicKey;
+  owner: PublicKey;
+  delegate?: PublicKey;
+  leafIndex: number | bigint;
+  sellerFeeBasisPointsRaw?: number;
+  creatorsRaw?: Array<Creator>;
+  assetData?: string | Uint8Array;
+  flags?: LeafSchemaV2Flags;
+  nftVersion?: number;
+};
+
 export function hashLeafV2(
   context: Pick<Context, 'eddsa' | 'programs'>,
-  input: {
-    merkleTree: PublicKey;
-    owner: PublicKey;
-    delegate?: PublicKey;
-    leafIndex: number | bigint;
-    metadata: MetadataArgsV2Args;
-    assetData?: string | Uint8Array;
-    flags?: LeafSchemaV2Flags;
-    nftVersion?: number;
-  }
+  input: HashLeafV2Input & { metadata: MetadataArgsV2Args }
+): Uint8Array;
+export function hashLeafV2(
+  context: Pick<Context, 'eddsa' | 'programs'>,
+  input: HashLeafV2Input & { metadata: MetadataArgsArgs }
+): Uint8Array;
+export function hashLeafV2(
+  context: Pick<Context, 'eddsa' | 'programs'>,
+  input: HashLeafV2Input & { metadata: V2OrV1Metadata }
 ): Uint8Array {
   const delegate = input.delegate ?? input.owner;
   const nftVersion = input.nftVersion ?? 2;
@@ -78,10 +103,14 @@ export function hashLeafV2(
     merkleTree: input.merkleTree,
     leafIndex: input.leafIndex,
   });
+  const metadata = toLeafMetadataV2(input.metadata, {
+    sellerFeeBasisPointsRaw: input.sellerFeeBasisPointsRaw,
+    creatorsRaw: input.creatorsRaw,
+  });
 
-  const collectionOption = isOption(input.metadata.collection)
-    ? input.metadata.collection
-    : wrapNullable(input.metadata.collection);
+  const collectionOption = isOption(metadata.collection)
+    ? metadata.collection
+    : wrapNullable(metadata.collection);
 
   const collection = unwrapOption(collectionOption, () => defaultPublicKey());
 
@@ -97,38 +126,70 @@ export function hashLeafV2(
     publicKeySerializer().serialize(input.owner),
     publicKeySerializer().serialize(delegate),
     u64().serialize(input.leafIndex),
-    hashMetadataV2(input.metadata),
+    hashMetadataV2(metadata),
     hashCollection(collection),
     hashAssetData(input.assetData),
     u8().serialize(flags),
   ]);
 }
 
-export function hashMetadata(metadata: MetadataArgsArgs): Uint8Array {
+export function hashMetadata(
+  metadata: MetadataArgsArgs,
+  raw?: RoyaltyRawFields
+): Uint8Array {
+  const leaf = toLeafMetadata(metadata, raw);
   return mergeBytes([
-    hashMetadataData(metadata),
-    hashMetadataCreators(metadata.creators),
+    hashMetadataData(leaf),
+    hashMetadataCreators(leaf.creators),
   ]);
 }
 
-export function hashMetadataV2(metadata: MetadataArgsV2Args): Uint8Array {
+export function hashMetadataV2(
+  metadata: MetadataArgsV2Args,
+  raw?: RoyaltyRawFields
+): Uint8Array;
+export function hashMetadataV2(
+  metadata: MetadataArgsArgs,
+  raw?: RoyaltyRawFields
+): Uint8Array;
+export function hashMetadataV2(
+  metadata: V2OrV1Metadata,
+  raw?: RoyaltyRawFields
+): Uint8Array {
+  const leaf = toLeafMetadataV2(metadata, raw);
   return mergeBytes([
-    hashMetadataDataV2(metadata),
-    hashMetadataCreators(metadata.creators),
+    hashMetadataDataV2(leaf),
+    hashMetadataCreators(leaf.creators),
   ]);
 }
 
-export function hashMetadataData(metadata: MetadataArgsArgs): Uint8Array {
+export function hashMetadataData(
+  metadata: MetadataArgsArgs,
+  raw?: RoyaltyRawFields
+): Uint8Array {
+  const leaf = toLeafMetadata(metadata, raw);
   return hash([
-    hash(getMetadataArgsSerializer().serialize(metadata)),
-    u16().serialize(metadata.sellerFeeBasisPoints),
+    hash(getMetadataArgsSerializer().serialize(leaf)),
+    u16().serialize(leaf.sellerFeeBasisPoints),
   ]);
 }
 
-export function hashMetadataDataV2(metadata: MetadataArgsV2Args): Uint8Array {
+export function hashMetadataDataV2(
+  metadata: MetadataArgsV2Args,
+  raw?: RoyaltyRawFields
+): Uint8Array;
+export function hashMetadataDataV2(
+  metadata: MetadataArgsArgs,
+  raw?: RoyaltyRawFields
+): Uint8Array;
+export function hashMetadataDataV2(
+  metadata: V2OrV1Metadata,
+  raw?: RoyaltyRawFields
+): Uint8Array {
+  const leaf = toLeafMetadataV2(metadata, raw);
   return hash([
-    hash(getMetadataArgsV2Serializer().serialize(metadata)),
-    u16().serialize(metadata.sellerFeeBasisPoints),
+    hash(getMetadataArgsV2Serializer().serialize(leaf)),
+    u16().serialize(leaf.sellerFeeBasisPoints),
   ]);
 }
 

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -6,6 +6,7 @@ export * from './getAssetWithProof';
 export * from './hash';
 export * from './hooked';
 export * from './leafAssetId';
+export * from './leafMetadata';
 export * from './merkle';
 export * from './plugin';
 export * from './canTransfer';

--- a/clients/js/src/leafMetadata.ts
+++ b/clients/js/src/leafMetadata.ts
@@ -1,4 +1,10 @@
-import { none, some, unwrapOption } from '@metaplex-foundation/umi';
+import {
+  isOption,
+  none,
+  some,
+  unwrapOption,
+  wrapNullable,
+} from '@metaplex-foundation/umi';
 import {
   Creator,
   MetadataArgs,
@@ -69,7 +75,10 @@ export const toLeafMetadataV2 = (
 ): MetadataArgsV2Args => {
   if (isV1MetadataArgs(metadata)) {
     const leaf = resolveLeafRoyaltyFields(metadata, raw) as MetadataArgs;
-    const collection = unwrapOption(leaf.collection);
+    const collectionOption = isOption(leaf.collection)
+      ? leaf.collection
+      : wrapNullable(leaf.collection);
+    const collection = unwrapOption(collectionOption, () => null);
     return {
       name: leaf.name,
       symbol: leaf.symbol,
@@ -90,7 +99,7 @@ export const toLeafMetadataV2 = (
 
 /** Minimal shape for {@link asCurrentMetadata} / {@link asCurrentMetadataV2}. */
 export type AssetRoyaltySource = {
-  metadata: MetadataArgsArgs;
+  metadata: MetadataArgsArgs | MetadataArgsV2Args;
   sellerFeeBasisPointsRaw?: number;
   creatorsRaw?: Array<Creator>;
 };
@@ -99,9 +108,11 @@ export type AssetRoyaltySource = {
  * Leaf-canonical V1 metadata for write ixs / hashing from an AssetWithProof-like
  * value using explicit `_raw` siblings.
  */
-export const asCurrentMetadata = (
-  asset: AssetRoyaltySource
-): MetadataArgsArgs =>
+export const asCurrentMetadata = (asset: {
+  metadata: MetadataArgsArgs;
+  sellerFeeBasisPointsRaw?: number;
+  creatorsRaw?: Array<Creator>;
+}): MetadataArgsArgs =>
   toLeafMetadata(asset.metadata, {
     sellerFeeBasisPointsRaw: asset.sellerFeeBasisPointsRaw,
     creatorsRaw: asset.creatorsRaw,

--- a/clients/js/src/leafMetadata.ts
+++ b/clients/js/src/leafMetadata.ts
@@ -1,0 +1,120 @@
+import { none, some, unwrapOption } from '@metaplex-foundation/umi';
+import {
+  Creator,
+  MetadataArgs,
+  MetadataArgsArgs,
+  MetadataArgsV2Args,
+} from './generated';
+
+/** DAS-aligned leaf royalty companions (mirrors `basis_points_raw` / `creators_raw`). */
+export type RoyaltyRawFields = {
+  sellerFeeBasisPointsRaw?: number;
+  creatorsRaw?: Array<Creator>;
+};
+
+/**
+ * True when `metadata` is V1 `MetadataArgs` shape (has `tokenProgramVersion`),
+ * as produced by `getAssetWithProof`.
+ */
+export const isV1MetadataArgs = (metadata: unknown): metadata is MetadataArgs =>
+  typeof metadata === 'object' &&
+  metadata !== null &&
+  'tokenProgramVersion' in metadata;
+
+/**
+ * Merge optional leaf royalty companions into metadata, then strip them.
+ * Resolution order: explicit `raw` arg → fields on `metadata`.
+ */
+export const resolveLeafRoyaltyFields = <
+  T extends { sellerFeeBasisPoints: number; creators: Array<Creator> },
+>(
+  metadata: T & RoyaltyRawFields,
+  raw?: RoyaltyRawFields
+): T => {
+  const sellerFeeBasisPointsRaw =
+    raw?.sellerFeeBasisPointsRaw ?? metadata.sellerFeeBasisPointsRaw;
+  const creatorsRaw = raw?.creatorsRaw ?? metadata.creatorsRaw;
+  const rest = { ...metadata };
+  delete rest.sellerFeeBasisPointsRaw;
+  delete rest.creatorsRaw;
+
+  if (sellerFeeBasisPointsRaw === undefined && creatorsRaw === undefined) {
+    return rest as T;
+  }
+  return {
+    ...(rest as T),
+    sellerFeeBasisPoints:
+      sellerFeeBasisPointsRaw ?? (rest as T).sellerFeeBasisPoints,
+    creators: creatorsRaw ?? (rest as T).creators,
+  };
+};
+
+/**
+ * Build leaf-canonical V1 metadata for write instructions / hashing.
+ * Pass AssetWithProof sibling raw fields as the second argument when present.
+ */
+export const toLeafMetadata = (
+  metadata: MetadataArgsArgs & RoyaltyRawFields,
+  raw?: RoyaltyRawFields
+): MetadataArgsArgs => resolveLeafRoyaltyFields(metadata, raw);
+
+/**
+ * Build leaf-canonical V2 metadata for write instructions / hashing.
+ * Accepts V1 `MetadataArgs` from `getAssetWithProof` (converts collection) or
+ * native `MetadataArgsV2Args`, plus optional AssetWithProof sibling raw fields.
+ */
+export const toLeafMetadataV2 = (
+  metadata: (MetadataArgsArgs | MetadataArgsV2Args) & RoyaltyRawFields,
+  raw?: RoyaltyRawFields
+): MetadataArgsV2Args => {
+  if (isV1MetadataArgs(metadata)) {
+    const leaf = resolveLeafRoyaltyFields(metadata, raw) as MetadataArgs;
+    const collection = unwrapOption(leaf.collection);
+    return {
+      name: leaf.name,
+      symbol: leaf.symbol,
+      uri: leaf.uri,
+      sellerFeeBasisPoints: leaf.sellerFeeBasisPoints,
+      primarySaleHappened: leaf.primarySaleHappened,
+      isMutable: leaf.isMutable,
+      tokenStandard: leaf.tokenStandard,
+      creators: leaf.creators,
+      collection: collection ? some(collection.key) : none(),
+    };
+  }
+  return resolveLeafRoyaltyFields(
+    metadata as MetadataArgsV2Args & RoyaltyRawFields,
+    raw
+  );
+};
+
+/** Minimal shape for {@link asCurrentMetadata} / {@link asCurrentMetadataV2}. */
+export type AssetRoyaltySource = {
+  metadata: MetadataArgsArgs;
+  sellerFeeBasisPointsRaw?: number;
+  creatorsRaw?: Array<Creator>;
+};
+
+/**
+ * Leaf-canonical V1 metadata for write ixs / hashing from an AssetWithProof-like
+ * value using explicit `_raw` siblings.
+ */
+export const asCurrentMetadata = (
+  asset: AssetRoyaltySource
+): MetadataArgsArgs =>
+  toLeafMetadata(asset.metadata, {
+    sellerFeeBasisPointsRaw: asset.sellerFeeBasisPointsRaw,
+    creatorsRaw: asset.creatorsRaw,
+  });
+
+/**
+ * Leaf-canonical V2 metadata for write ixs / hashing from an AssetWithProof-like
+ * value (converts collection to pubkey option).
+ */
+export const asCurrentMetadataV2 = (
+  asset: AssetRoyaltySource
+): MetadataArgsV2Args =>
+  toLeafMetadataV2(asset.metadata, {
+    sellerFeeBasisPointsRaw: asset.sellerFeeBasisPointsRaw,
+    creatorsRaw: asset.creatorsRaw,
+  });

--- a/clients/js/test/dasApi.test.ts
+++ b/clients/js/test/dasApi.test.ts
@@ -701,11 +701,7 @@ test('it exposes resolved and current metadata for inherited SFBP', async (t) =>
   // When we fetch its asset and proof.
   const asset = await getAssetWithProof(umi, assetId);
 
-  // Then reads use DAS-resolved royalties.
-  t.is(asset.metadata.sellerFeeBasisPoints, 750);
-  t.is(asset.metadata.creators.length, 1);
-
-  // And writes use the canonical values hashed into the leaf.
+  // Writes / hashing always use the leaf sentinel for this inherited asset.
   t.true(asset.inherited);
   t.is(asset.sellerFeeBasisPointsRaw, SELLER_FEE_BASIS_POINTS_INHERIT);
   t.deepEqual(asset.creatorsRaw, []);
@@ -715,4 +711,16 @@ test('it exposes resolved and current metadata for inherited SFBP', async (t) =>
   );
   t.deepEqual(asset.currentMetadata.creators, []);
   t.deepEqual(asset.currentMetadata.collection, some(collection));
+
+  // Display fields: DAS 2.1.1 types include resolved `basis_points` + `_raw`,
+  // but the live indexer may still return the leaf sentinel until that ships.
+  if (
+    asset.rpcAsset.royalty?.inherited ||
+    asset.rpcAsset.royalty?.basis_points_raw != null
+  ) {
+    t.is(asset.metadata.sellerFeeBasisPoints, 750);
+    t.is(asset.metadata.creators.length, 1);
+  } else {
+    t.is(asset.metadata.sellerFeeBasisPoints, SELLER_FEE_BASIS_POINTS_INHERIT);
+  }
 });

--- a/clients/js/test/dasApi.test.ts
+++ b/clients/js/test/dasApi.test.ts
@@ -19,6 +19,7 @@ import {
   AssetWithProof,
   getAssetWithProof,
   mplBubblegum,
+  SELLER_FEE_BASIS_POINTS_INHERIT,
   TokenProgramVersion,
   TokenStandard,
 } from '../src';
@@ -134,7 +135,7 @@ test('it can fetch the proof of a compressed asset', async (t) => {
 
   // Then we expect the following data
   // with a proof length of 14.
-  t.like(asset, <AssetWithProof>{
+  t.like(asset, <Partial<AssetWithProof>>{
     leafOwner: publicKey('EczRmPqSEWBXtcMKVK1avV87EXH5JZrRbTVdUJdnYaKo'),
     leafDelegate: publicKey('EczRmPqSEWBXtcMKVK1avV87EXH5JZrRbTVdUJdnYaKo'),
     merkleTree: publicKey('6tPxkhcjcfR7rXsnGwzh8rPnkiYt2r6tDGN1TUv4T15E'),
@@ -173,17 +174,7 @@ test('it can fetch the proof of a compressed asset', async (t) => {
       tokenProgramVersion: TokenProgramVersion.Original,
       creators: [],
     },
-    currentMetadata: {
-      name: 'My NFT',
-      symbol: '',
-      uri: 'https://example.com/my-nft.json',
-      sellerFeeBasisPoints: 500,
-      primarySaleHappened: false,
-      isMutable: true,
-      tokenStandard: some(TokenStandard.NonFungible),
-      collection: none(),
-      creators: [],
-    },
+    inherited: false,
     rpcAsset: {
       interface: 'V1_NFT',
       id: assetId,
@@ -268,7 +259,7 @@ test('it can fetch the truncated proof of a compressed asset with canopy depth 0
 
   // Then we expect the following data
   // with a proof length of 14.
-  t.like(asset, <AssetWithProof>{
+  t.like(asset, <Partial<AssetWithProof>>{
     leafOwner: publicKey('EczRmPqSEWBXtcMKVK1avV87EXH5JZrRbTVdUJdnYaKo'),
     leafDelegate: publicKey('EczRmPqSEWBXtcMKVK1avV87EXH5JZrRbTVdUJdnYaKo'),
     merkleTree: publicKey('6tPxkhcjcfR7rXsnGwzh8rPnkiYt2r6tDGN1TUv4T15E'),
@@ -307,17 +298,7 @@ test('it can fetch the truncated proof of a compressed asset with canopy depth 0
       tokenProgramVersion: TokenProgramVersion.Original,
       creators: [],
     },
-    currentMetadata: {
-      name: 'My NFT',
-      symbol: '',
-      uri: 'https://example.com/my-nft.json',
-      sellerFeeBasisPoints: 500,
-      primarySaleHappened: false,
-      isMutable: true,
-      tokenStandard: some(TokenStandard.NonFungible),
-      collection: none(),
-      creators: [],
-    },
+    inherited: false,
     rpcAsset: {
       interface: 'V1_NFT',
       id: assetId,
@@ -402,7 +383,7 @@ test('it can fetch the proof of a compressed asset with nonzero canopy depth', a
 
   // Then we expect the following data
   // with a proof length of 14.
-  t.like(asset, <AssetWithProof>{
+  t.like(asset, <Partial<AssetWithProof>>{
     leafOwner: publicKey('BJjUoux3xacYcRZV31Ytsi4haJb3HgyzmweVDHutiLWU'),
     leafDelegate: publicKey('BJjUoux3xacYcRZV31Ytsi4haJb3HgyzmweVDHutiLWU'),
     merkleTree: publicKey('B6RTei821Mi4ZAFqXGCCeHMJbixnweFJMY49UZBs4LWN'),
@@ -455,30 +436,7 @@ test('it can fetch the proof of a compressed asset with nonzero canopy depth', a
         },
       ],
     },
-    currentMetadata: {
-      name: 'Welcome to Creator Studio',
-      symbol: 'CS',
-      uri: 'https://arweave.net/0h9bJ_dST9JN7jdYgfW5SoTQ5b_6zYkpX7x5nLkeeD0',
-      sellerFeeBasisPoints: 0,
-      primarySaleHappened: false,
-      isMutable: false,
-      tokenStandard: some(TokenStandard.NonFungible),
-      collection: some(
-        publicKey('5141VSFjgYFEKTy45aT1tUEeApwQ1eXPEfzRdRVt7xTL')
-      ),
-      creators: [
-        {
-          address: publicKey('3HxqsUguP6E7CNqjvpEAnJ8v86qbyJgWvN2idAKygLdD'),
-          share: 100,
-          verified: false,
-        },
-        {
-          address: publicKey('792RcrqqmoWUh6LbijAfpAkxR2kVCoBGrmshWzfy7HgD'),
-          share: 0,
-          verified: false,
-        },
-      ],
-    },
+    inherited: false,
     rpcAsset: {
       interface: 'V1_NFT',
       id: assetId,
@@ -581,7 +539,7 @@ test('it can fetch the truncated proof of a compressed asset with nonzero canopy
 
   // Then we expect the following data
   // with a proof length of 5.
-  t.like(asset, <AssetWithProof>{
+  t.like(asset, <Partial<AssetWithProof>>{
     leafOwner: publicKey('BJjUoux3xacYcRZV31Ytsi4haJb3HgyzmweVDHutiLWU'),
     leafDelegate: publicKey('BJjUoux3xacYcRZV31Ytsi4haJb3HgyzmweVDHutiLWU'),
     merkleTree: publicKey('B6RTei821Mi4ZAFqXGCCeHMJbixnweFJMY49UZBs4LWN'),
@@ -625,30 +583,7 @@ test('it can fetch the truncated proof of a compressed asset with nonzero canopy
         },
       ],
     },
-    currentMetadata: {
-      name: 'Welcome to Creator Studio',
-      symbol: 'CS',
-      uri: 'https://arweave.net/0h9bJ_dST9JN7jdYgfW5SoTQ5b_6zYkpX7x5nLkeeD0',
-      sellerFeeBasisPoints: 0,
-      primarySaleHappened: false,
-      isMutable: false,
-      tokenStandard: some(TokenStandard.NonFungible),
-      collection: some(
-        publicKey('5141VSFjgYFEKTy45aT1tUEeApwQ1eXPEfzRdRVt7xTL')
-      ),
-      creators: [
-        {
-          address: publicKey('3HxqsUguP6E7CNqjvpEAnJ8v86qbyJgWvN2idAKygLdD'),
-          share: 100,
-          verified: false,
-        },
-        {
-          address: publicKey('792RcrqqmoWUh6LbijAfpAkxR2kVCoBGrmshWzfy7HgD'),
-          share: 0,
-          verified: false,
-        },
-      ],
-    },
+    inherited: false,
     rpcAsset: {
       interface: 'V1_NFT',
       id: assetId,
@@ -755,4 +690,29 @@ test('it can fetch a compressed asset with grouping verified set to false', asyn
     false,
     'First grouping should have verified set to false'
   );
+});
+
+test('it exposes resolved and current metadata for inherited SFBP', async (t) => {
+  // Given an inherited-SFBP Bubblegum V2 asset indexed by DAS.
+  const { umi } = t.context;
+  const assetId = publicKey('BzQPqccY1c88XeVfvvqrJsryHYMcPuxKiCVo4R6MDznv');
+  const collection = publicKey('HgLnYtaZ9Nd1PqoGXh9rPXSMo6xUpUd6D5tsV8RUs7Qf');
+
+  // When we fetch its asset and proof.
+  const asset = await getAssetWithProof(umi, assetId);
+
+  // Then reads use DAS-resolved royalties.
+  t.is(asset.metadata.sellerFeeBasisPoints, 750);
+  t.is(asset.metadata.creators.length, 1);
+
+  // And writes use the canonical values hashed into the leaf.
+  t.true(asset.inherited);
+  t.is(asset.sellerFeeBasisPointsRaw, SELLER_FEE_BASIS_POINTS_INHERIT);
+  t.deepEqual(asset.creatorsRaw, []);
+  t.is(
+    asset.currentMetadata.sellerFeeBasisPoints,
+    SELLER_FEE_BASIS_POINTS_INHERIT
+  );
+  t.deepEqual(asset.currentMetadata.creators, []);
+  t.deepEqual(asset.currentMetadata.collection, some(collection));
 });

--- a/clients/js/test/leafMetadata.test.ts
+++ b/clients/js/test/leafMetadata.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { none, publicKey, some } from '@metaplex-foundation/umi';
+import { none, publicKey, some, unwrapOption } from '@metaplex-foundation/umi';
 import {
   MetadataArgs,
   SELLER_FEE_BASIS_POINTS_INHERIT,
@@ -48,7 +48,7 @@ test('toLeafMetadataV2 converts getAssetWithProof metadata + sibling raw', (t) =
   });
   t.is(leaf.sellerFeeBasisPoints, SELLER_FEE_BASIS_POINTS_INHERIT);
   t.deepEqual(leaf.creators, []);
-  t.deepEqual(leaf.collection, some(coreCollection));
+  t.is(unwrapOption(leaf.collection), coreCollection);
   t.false('tokenProgramVersion' in leaf);
 });
 
@@ -63,7 +63,10 @@ test('asCurrentMetadata / asCurrentMetadataV2 sugar', (t) => {
     asCurrentMetadata(asset).sellerFeeBasisPoints,
     SELLER_FEE_BASIS_POINTS_INHERIT
   );
-  t.deepEqual(asCurrentMetadataV2(asset).collection, some(coreCollection));
+  t.is(
+    unwrapOption(asCurrentMetadataV2(asset).collection),
+    coreCollection
+  );
 });
 
 test('toLeafMetadata leaves explicit leaf metadata unchanged without raw', (t) => {
@@ -100,7 +103,7 @@ test('toLeafMetadataV2 accepts native MetadataArgsV2Args', (t) => {
   });
   t.is(leaf.sellerFeeBasisPoints, SELLER_FEE_BASIS_POINTS_INHERIT);
   t.deepEqual(leaf.creators, []);
-  t.deepEqual(leaf.collection, some(coreCollection));
+  t.is(unwrapOption(leaf.collection), coreCollection);
 });
 
 test('toLeafMetadataV2 handles null and plain collection values', (t) => {
@@ -108,14 +111,14 @@ test('toLeafMetadataV2 handles null and plain collection values', (t) => {
     ...resolvedMetadata,
     collection: null,
   };
-  t.deepEqual(toLeafMetadataV2(withNullCollection).collection, none());
+  t.is(unwrapOption(toLeafMetadataV2(withNullCollection).collection), null);
 
   const withPlainCollection = {
     ...resolvedMetadata,
     collection: { key: coreCollection, verified: true },
   };
-  t.deepEqual(
-    toLeafMetadataV2(withPlainCollection).collection,
-    some(coreCollection)
+  t.is(
+    unwrapOption(toLeafMetadataV2(withPlainCollection).collection),
+    coreCollection
   );
 });

--- a/clients/js/test/leafMetadata.test.ts
+++ b/clients/js/test/leafMetadata.test.ts
@@ -85,3 +85,37 @@ test('toLeafMetadata leaves explicit leaf metadata unchanged without raw', (t) =
   t.is(leaf.sellerFeeBasisPoints, 550);
   t.is(leaf.creators.length, 1);
 });
+
+test('toLeafMetadataV2 accepts native MetadataArgsV2Args', (t) => {
+  const v2 = {
+    name: 'V2 NFT',
+    uri: 'https://example.com/v2.json',
+    sellerFeeBasisPoints: 500,
+    collection: some(coreCollection),
+    creators: [{ address: payee, share: 100, verified: true }],
+  };
+  const leaf = toLeafMetadataV2(v2, {
+    sellerFeeBasisPointsRaw: SELLER_FEE_BASIS_POINTS_INHERIT,
+    creatorsRaw: [],
+  });
+  t.is(leaf.sellerFeeBasisPoints, SELLER_FEE_BASIS_POINTS_INHERIT);
+  t.deepEqual(leaf.creators, []);
+  t.deepEqual(leaf.collection, some(coreCollection));
+});
+
+test('toLeafMetadataV2 handles null and plain collection values', (t) => {
+  const withNullCollection = {
+    ...resolvedMetadata,
+    collection: null,
+  };
+  t.deepEqual(toLeafMetadataV2(withNullCollection).collection, none());
+
+  const withPlainCollection = {
+    ...resolvedMetadata,
+    collection: { key: coreCollection, verified: true },
+  };
+  t.deepEqual(
+    toLeafMetadataV2(withPlainCollection).collection,
+    some(coreCollection)
+  );
+});

--- a/clients/js/test/leafMetadata.test.ts
+++ b/clients/js/test/leafMetadata.test.ts
@@ -1,0 +1,87 @@
+import test from 'ava';
+import { none, publicKey, some } from '@metaplex-foundation/umi';
+import {
+  MetadataArgs,
+  SELLER_FEE_BASIS_POINTS_INHERIT,
+  TokenProgramVersion,
+  TokenStandard,
+  asCurrentMetadata,
+  asCurrentMetadataV2,
+  toLeafMetadata,
+  toLeafMetadataV2,
+} from '../src';
+
+const coreCollection = publicKey(
+  '7USYF5BnFo4FuE8eRoEqEvSvZSEaMG5AqPCQbLQ5BxPL'
+);
+const payee = publicKey('HjzLbPCVGFjXAo5HXS5fpQmXjQE6FMgDEPvFZon7rC7G');
+
+const resolvedMetadata: MetadataArgs = {
+  name: 'My NFT',
+  symbol: '',
+  uri: 'https://example.com/my-nft.json',
+  sellerFeeBasisPoints: 500,
+  primarySaleHappened: false,
+  isMutable: true,
+  editionNonce: none(),
+  tokenStandard: some(TokenStandard.NonFungible),
+  collection: some({ key: coreCollection, verified: true }),
+  uses: none(),
+  tokenProgramVersion: TokenProgramVersion.Original,
+  creators: [{ address: payee, share: 100, verified: true }],
+};
+
+test('toLeafMetadata applies explicit sibling raw fields', (t) => {
+  const leaf = toLeafMetadata(resolvedMetadata, {
+    sellerFeeBasisPointsRaw: SELLER_FEE_BASIS_POINTS_INHERIT,
+    creatorsRaw: [],
+  });
+  t.is(leaf.sellerFeeBasisPoints, SELLER_FEE_BASIS_POINTS_INHERIT);
+  t.deepEqual(leaf.creators, []);
+  t.is(resolvedMetadata.sellerFeeBasisPoints, 500);
+});
+
+test('toLeafMetadataV2 converts getAssetWithProof metadata + sibling raw', (t) => {
+  const leaf = toLeafMetadataV2(resolvedMetadata, {
+    sellerFeeBasisPointsRaw: SELLER_FEE_BASIS_POINTS_INHERIT,
+    creatorsRaw: [],
+  });
+  t.is(leaf.sellerFeeBasisPoints, SELLER_FEE_BASIS_POINTS_INHERIT);
+  t.deepEqual(leaf.creators, []);
+  t.deepEqual(leaf.collection, some(coreCollection));
+  t.false('tokenProgramVersion' in leaf);
+});
+
+test('asCurrentMetadata / asCurrentMetadataV2 sugar', (t) => {
+  const asset = {
+    metadata: resolvedMetadata,
+    sellerFeeBasisPointsRaw: SELLER_FEE_BASIS_POINTS_INHERIT,
+    creatorsRaw: [] as MetadataArgs['creators'],
+    inherited: true,
+  };
+  t.is(
+    asCurrentMetadata(asset).sellerFeeBasisPoints,
+    SELLER_FEE_BASIS_POINTS_INHERIT
+  );
+  t.deepEqual(asCurrentMetadataV2(asset).collection, some(coreCollection));
+});
+
+test('toLeafMetadata leaves explicit leaf metadata unchanged without raw', (t) => {
+  const explicit: MetadataArgs = {
+    name: 'X',
+    symbol: '',
+    uri: 'https://example.com/x.json',
+    sellerFeeBasisPoints: 550,
+    primarySaleHappened: false,
+    isMutable: true,
+    editionNonce: none(),
+    tokenStandard: some(TokenStandard.NonFungible),
+    collection: none(),
+    uses: none(),
+    tokenProgramVersion: TokenProgramVersion.Original,
+    creators: [{ address: payee, share: 100, verified: false }],
+  };
+  const leaf = toLeafMetadata(explicit);
+  t.is(leaf.sellerFeeBasisPoints, 550);
+  t.is(leaf.creators.length, 1);
+});

--- a/clients/js/test/leafMetadata.test.ts
+++ b/clients/js/test/leafMetadata.test.ts
@@ -1,5 +1,14 @@
 import test from 'ava';
-import { none, publicKey, some, unwrapOption } from '@metaplex-foundation/umi';
+import {
+  isOption,
+  none,
+  OptionOrNullable,
+  PublicKey,
+  publicKey,
+  some,
+  unwrapOption,
+  wrapNullable,
+} from '@metaplex-foundation/umi';
 import {
   MetadataArgs,
   SELLER_FEE_BASIS_POINTS_INHERIT,
@@ -10,6 +19,9 @@ import {
   toLeafMetadata,
   toLeafMetadataV2,
 } from '../src';
+
+const unwrapCollection = (value: OptionOrNullable<PublicKey>) =>
+  unwrapOption(isOption(value) ? value : wrapNullable(value), () => null);
 
 const coreCollection = publicKey(
   '7USYF5BnFo4FuE8eRoEqEvSvZSEaMG5AqPCQbLQ5BxPL'
@@ -48,7 +60,7 @@ test('toLeafMetadataV2 converts getAssetWithProof metadata + sibling raw', (t) =
   });
   t.is(leaf.sellerFeeBasisPoints, SELLER_FEE_BASIS_POINTS_INHERIT);
   t.deepEqual(leaf.creators, []);
-  t.is(unwrapOption(leaf.collection), coreCollection);
+  t.is(unwrapCollection(leaf.collection), coreCollection);
   t.false('tokenProgramVersion' in leaf);
 });
 
@@ -63,10 +75,7 @@ test('asCurrentMetadata / asCurrentMetadataV2 sugar', (t) => {
     asCurrentMetadata(asset).sellerFeeBasisPoints,
     SELLER_FEE_BASIS_POINTS_INHERIT
   );
-  t.is(
-    unwrapOption(asCurrentMetadataV2(asset).collection),
-    coreCollection
-  );
+  t.is(unwrapCollection(asCurrentMetadataV2(asset).collection), coreCollection);
 });
 
 test('toLeafMetadata leaves explicit leaf metadata unchanged without raw', (t) => {
@@ -103,7 +112,7 @@ test('toLeafMetadataV2 accepts native MetadataArgsV2Args', (t) => {
   });
   t.is(leaf.sellerFeeBasisPoints, SELLER_FEE_BASIS_POINTS_INHERIT);
   t.deepEqual(leaf.creators, []);
-  t.is(unwrapOption(leaf.collection), coreCollection);
+  t.is(unwrapCollection(leaf.collection), coreCollection);
 });
 
 test('toLeafMetadataV2 handles null and plain collection values', (t) => {
@@ -111,14 +120,14 @@ test('toLeafMetadataV2 handles null and plain collection values', (t) => {
     ...resolvedMetadata,
     collection: null,
   };
-  t.is(unwrapOption(toLeafMetadataV2(withNullCollection).collection), null);
+  t.is(unwrapCollection(toLeafMetadataV2(withNullCollection).collection), null);
 
   const withPlainCollection = {
     ...resolvedMetadata,
     collection: { key: coreCollection, verified: true },
   };
   t.is(
-    unwrapOption(toLeafMetadataV2(withPlainCollection).collection),
+    unwrapCollection(toLeafMetadataV2(withPlainCollection).collection),
     coreCollection
   );
 });

--- a/clients/js/test/updateMetadataV2.test.ts
+++ b/clients/js/test/updateMetadataV2.test.ts
@@ -18,6 +18,11 @@ import {
   getCurrentRoot,
 } from '@metaplex-foundation/mpl-account-compression';
 import {
+  CompressionAccountType,
+  getConcurrentMerkleTreeHeaderSerializer,
+  getMerkleTreeSize,
+} from '@metaplex-foundation/spl-account-compression';
+import {
   UpdateArgsArgs,
   findLeafAssetIdPda,
   getAssetWithProof,
@@ -333,6 +338,72 @@ test('getAssetWithProof exposes resolved metadata with DAS-aligned _raw fields',
   t.is(assetWithProof.rpcAsset.royalty?.basis_points, 500);
   t.is(assetWithProof.rpcAsset.creators?.length, 1);
   t.deepEqual(assetWithProof.rpcAsset.creators_raw, []);
+});
+
+test('getAssetWithProof truncateCanopy reads header space instead of the full tree', async (t) => {
+  const assetId = publicKey('EczRmPqSEWBXtcMKVK1avV87EXH5JZrRbTVdUJdnYaKo');
+  const merkleTree = publicKey('BJjUoux3xacYcRZV31Ytsi4haJb3HgyzmweVDHutiLWU');
+  const leafOwner = publicKey('HjzLbPCVGFjXAo5HXS5fpQmXjQE6FMgDEPvFZon7rC7G');
+  const proof = Array.from({ length: 14 }, () => defaultPublicKey());
+  const headerBytes = getConcurrentMerkleTreeHeaderSerializer().serialize({
+    accountType: CompressionAccountType.ConcurrentMerkleTree,
+    header: {
+      __kind: 'V1',
+      maxBufferSize: 64,
+      maxDepth: 14,
+      authority: defaultPublicKey(),
+      creationSlot: 0,
+      padding: [0, 0, 0, 0, 0, 0],
+    },
+  });
+  const headerBase64 = Buffer.from(headerBytes).toString('base64');
+  let fetchedFullAccount = false;
+
+  const rpcAsset = {
+    ownership: { owner: leafOwner },
+    content: {
+      metadata: { name: 'My NFT', symbol: '' },
+      json_uri: 'https://example.com/my-nft.json',
+    },
+    royalty: { basis_points: 500, primary_sale_happened: false },
+    mutable: true,
+    supply: {},
+    creators: [],
+    grouping: [],
+    compression: {
+      leaf_id: 0,
+      data_hash: defaultPublicKey(),
+      creator_hash: defaultPublicKey(),
+    },
+  } as unknown as DasApiAsset;
+  const context = {
+    rpc: {
+      getAsset: async () => rpcAsset,
+      getAssetProof: async () =>
+        ({
+          proof,
+          root: defaultPublicKey(),
+          tree_id: merkleTree,
+          node_index: 1,
+        }) as GetAssetProofRpcResponse,
+      getAccount: async () => {
+        fetchedFullAccount = true;
+        throw new Error('should not fetch the full merkle tree');
+      },
+      call: async () => ({
+        value: {
+          data: [headerBase64, 'base64'],
+          space: getMerkleTreeSize(14, 64, 9),
+        },
+      }),
+    },
+  } as unknown as Parameters<typeof getAssetWithProof>[0];
+
+  const assetWithProof = await getAssetWithProof(context, assetId, {
+    truncateCanopy: true,
+  });
+  t.false(fetchedFullAccount);
+  t.is(assetWithProof.proof.length, 5);
 });
 
 test('getAssetWithProof recovers leaf _raw when DAS still returns the inherit sentinel in basis_points', async (t) => {

--- a/clients/js/test/updateMetadataV2.test.ts
+++ b/clients/js/test/updateMetadataV2.test.ts
@@ -248,8 +248,8 @@ test('it can update metadata using the getAssetWithProof helper using V2 instruc
   t.is(assetWithProof.rpcAssetProof, rpcAssetProof);
 });
 
-test('getAssetWithProof infers inherited seller fee metadata from the data hash', async (t) => {
-  // Given a DAS asset whose royalty basis points are resolved from the collection.
+test('getAssetWithProof exposes resolved metadata with DAS-aligned _raw fields', async (t) => {
+  // Given a DAS asset with leaf sentinel SFBP and collection-resolved inherited fields.
   const assetId = publicKey('EczRmPqSEWBXtcMKVK1avV87EXH5JZrRbTVdUJdnYaKo');
   const merkleTree = publicKey('BJjUoux3xacYcRZV31Ytsi4haJb3HgyzmweVDHutiLWU');
   const leafOwner = publicKey('HjzLbPCVGFjXAo5HXS5fpQmXjQE6FMgDEPvFZon7rC7G');
@@ -271,11 +271,14 @@ test('getAssetWithProof infers inherited seller fee metadata from the data hash'
     },
     royalty: {
       basis_points: 500,
+      basis_points_raw: SELLER_FEE_BASIS_POINTS_INHERIT,
+      inherited: true,
       primary_sale_happened: false,
     },
     mutable: true,
     supply: {},
-    creators: [],
+    creators: [{ address: leafOwner, share: 100, verified: true }],
+    creators_raw: [],
     grouping: [
       {
         group_key: 'collection',
@@ -308,91 +311,31 @@ test('getAssetWithProof infers inherited seller fee metadata from the data hash'
   // When we use the getAssetWithProof helper.
   const assetWithProof = await getAssetWithProof(context, assetId);
 
-  // Then metadata uses the resolved value, while currentMetadata keeps the sentinel for hashing.
+  // Then metadata mirrors DAS main (resolved) fields for reading.
   t.is(assetWithProof.metadata.sellerFeeBasisPoints, 500);
+  t.is(assetWithProof.metadata.creators.length, 1);
+  t.is(assetWithProof.metadata.creators[0].address, leafOwner);
+  // And DAS-aligned sibling _raw fields expose the leaf values.
+  t.is(assetWithProof.inherited, true);
+  t.is(assetWithProof.sellerFeeBasisPointsRaw, SELLER_FEE_BASIS_POINTS_INHERIT);
+  t.deepEqual(assetWithProof.creatorsRaw, []);
+  // The explicit currentMetadata is canonical for hashing and writes.
   t.is(
-    assetWithProof.currentMetadata!.sellerFeeBasisPoints,
+    assetWithProof.currentMetadata.sellerFeeBasisPoints,
     SELLER_FEE_BASIS_POINTS_INHERIT
   );
-  t.deepEqual(assetWithProof.currentMetadata!.collection, some(coreCollection));
+  t.deepEqual(assetWithProof.currentMetadata.creators, []);
+  t.deepEqual(assetWithProof.currentMetadata.collection, some(coreCollection));
+  t.deepEqual(
+    assetWithProof.metadata.collection,
+    some({ key: coreCollection, verified: true })
+  );
   t.is(assetWithProof.rpcAsset.royalty?.basis_points, 500);
+  t.is(assetWithProof.rpcAsset.creators?.length, 1);
+  t.deepEqual(assetWithProof.rpcAsset.creators_raw, []);
 });
 
-test('getAssetWithProof resolves inherited seller fee basis points with a collection resolver', async (t) => {
-  // Given a DAS asset whose royalty basis points are still the raw sentinel.
-  const assetId = publicKey('EczRmPqSEWBXtcMKVK1avV87EXH5JZrRbTVdUJdnYaKo');
-  const merkleTree = publicKey('BJjUoux3xacYcRZV31Ytsi4haJb3HgyzmweVDHutiLWU');
-  const leafOwner = publicKey('HjzLbPCVGFjXAo5HXS5fpQmXjQE6FMgDEPvFZon7rC7G');
-  const coreCollection = publicKey(
-    '7USYF5BnFo4FuE8eRoEqEvSvZSEaMG5AqPCQbLQ5BxPL'
-  );
-  const canonicalMetadata: MetadataArgsV2Args = {
-    name: 'My NFT',
-    uri: 'https://example.com/my-nft.json',
-    sellerFeeBasisPoints: SELLER_FEE_BASIS_POINTS_INHERIT,
-    collection: some(coreCollection),
-    creators: [],
-  };
-  const rpcAsset = {
-    ownership: { owner: leafOwner },
-    content: {
-      metadata: { name: 'My NFT', symbol: '' },
-      json_uri: 'https://example.com/my-nft.json',
-    },
-    royalty: {
-      basis_points: SELLER_FEE_BASIS_POINTS_INHERIT,
-      primary_sale_happened: false,
-    },
-    mutable: true,
-    supply: {},
-    creators: [],
-    grouping: [
-      {
-        group_key: 'collection',
-        group_value: coreCollection,
-        verified: true,
-      },
-    ],
-    compression: {
-      leaf_id: 0,
-      data_hash: publicKey(hashMetadataDataV2(canonicalMetadata)),
-      creator_hash: defaultPublicKey(),
-      collection_hash: publicKey(hashCollection(coreCollection)),
-      asset_data_hash: publicKey(hashAssetData()),
-      flags: LeafSchemaV2Flags.None,
-    },
-  } as unknown as DasApiAsset;
-  const rpcAssetProof = {
-    proof: [],
-    root: defaultPublicKey(),
-    tree_id: merkleTree,
-    node_index: 1,
-  } as unknown as GetAssetProofRpcResponse;
-  const context = {
-    rpc: {
-      getAsset: async () => rpcAsset,
-      getAssetProof: async () => rpcAssetProof,
-    },
-  } as unknown as Parameters<typeof getAssetWithProof>[0];
-
-  // When we use the getAssetWithProof helper with a collection royalty resolver.
-  const assetWithProof = await getAssetWithProof(context, assetId, {
-    resolveCollectionSellerFeeBasisPoints: (collection) => {
-      t.is(collection, coreCollection);
-      return 500;
-    },
-  });
-
-  // Then metadata uses the resolved value, while currentMetadata keeps the sentinel for hashing.
-  t.is(assetWithProof.metadata.sellerFeeBasisPoints, 500);
-  t.is(
-    assetWithProof.currentMetadata!.sellerFeeBasisPoints,
-    SELLER_FEE_BASIS_POINTS_INHERIT
-  );
-  t.deepEqual(assetWithProof.currentMetadata!.collection, some(coreCollection));
-});
-
-test('getAssetWithProof currentMetadata can update inherited seller fee assets', async (t) => {
+test('getAssetWithProof metadata can update inherited seller fee assets', async (t) => {
   // Given an empty Bubblegum tree.
   const umi = await createUmi();
   const merkleTree = await createTreeV2(umi);
@@ -450,13 +393,14 @@ test('getAssetWithProof currentMetadata can update inherited seller fee assets',
     },
     royalty: {
       basis_points: 500,
-      primary_sale_happened: false,
       basis_points_raw: SELLER_FEE_BASIS_POINTS_INHERIT,
-      sfbp_inherited: true,
+      inherited: true,
+      primary_sale_happened: false,
     },
     mutable: true,
     supply: {},
     creators: [],
+    creators_raw: [],
     grouping: [
       {
         group_key: 'collection',
@@ -486,17 +430,13 @@ test('getAssetWithProof currentMetadata can update inherited seller fee assets',
     },
   } as unknown as Parameters<typeof getAssetWithProof>[0];
 
-  // When we update from the helper output without overriding currentMetadata.
+  // When we spread getAssetWithProof directly into the write instruction.
   const assetWithProof = await getAssetWithProof(context, assetId);
   t.is(assetWithProof.metadata.sellerFeeBasisPoints, 500);
-  t.is(
-    assetWithProof.currentMetadata!.sellerFeeBasisPoints,
-    SELLER_FEE_BASIS_POINTS_INHERIT
-  );
+  t.is(assetWithProof.sellerFeeBasisPointsRaw, SELLER_FEE_BASIS_POINTS_INHERIT);
 
   await updateMetadataV2(umi, {
     ...assetWithProof,
-    currentMetadata: assetWithProof.currentMetadata!,
     authority: collectionUpdateAuthority,
     coreCollection: coreCollection.publicKey,
     updateArgs: {

--- a/clients/js/test/updateMetadataV2.test.ts
+++ b/clients/js/test/updateMetadataV2.test.ts
@@ -335,6 +335,74 @@ test('getAssetWithProof exposes resolved metadata with DAS-aligned _raw fields',
   t.deepEqual(assetWithProof.rpcAsset.creators_raw, []);
 });
 
+test('getAssetWithProof recovers leaf _raw when DAS still returns the inherit sentinel in basis_points', async (t) => {
+  const assetId = publicKey('EczRmPqSEWBXtcMKVK1avV87EXH5JZrRbTVdUJdnYaKo');
+  const merkleTree = publicKey('BJjUoux3xacYcRZV31Ytsi4haJb3HgyzmweVDHutiLWU');
+  const leafOwner = publicKey('HjzLbPCVGFjXAo5HXS5fpQmXjQE6FMgDEPvFZon7rC7G');
+  const coreCollection = publicKey(
+    '7USYF5BnFo4FuE8eRoEqEvSvZSEaMG5AqPCQbLQ5BxPL'
+  );
+  const canonicalMetadata: MetadataArgsV2Args = {
+    name: 'My NFT',
+    uri: 'https://example.com/my-nft.json',
+    sellerFeeBasisPoints: SELLER_FEE_BASIS_POINTS_INHERIT,
+    collection: some(coreCollection),
+    creators: [],
+  };
+  const rpcAsset = {
+    ownership: { owner: leafOwner },
+    content: {
+      metadata: { name: 'My NFT', symbol: '' },
+      json_uri: 'https://example.com/my-nft.json',
+    },
+    royalty: {
+      basis_points: SELLER_FEE_BASIS_POINTS_INHERIT,
+      primary_sale_happened: false,
+    },
+    mutable: true,
+    supply: {},
+    creators: [],
+    grouping: [
+      {
+        group_key: 'collection',
+        group_value: coreCollection,
+        verified: true,
+      },
+    ],
+    compression: {
+      leaf_id: 0,
+      data_hash: publicKey(hashMetadataDataV2(canonicalMetadata)),
+      creator_hash: defaultPublicKey(),
+      collection_hash: publicKey(hashCollection(coreCollection)),
+      asset_data_hash: publicKey(hashAssetData()),
+      flags: LeafSchemaV2Flags.None,
+    },
+  } as unknown as DasApiAsset;
+  const rpcAssetProof = {
+    proof: [],
+    root: defaultPublicKey(),
+    tree_id: merkleTree,
+    node_index: 1,
+  } as unknown as GetAssetProofRpcResponse;
+  const context = {
+    rpc: {
+      getAsset: async () => rpcAsset,
+      getAssetProof: async () => rpcAssetProof,
+    },
+  } as unknown as Parameters<typeof getAssetWithProof>[0];
+
+  const assetWithProof = await getAssetWithProof(context, assetId);
+
+  t.true(assetWithProof.inherited);
+  t.is(assetWithProof.sellerFeeBasisPointsRaw, SELLER_FEE_BASIS_POINTS_INHERIT);
+  t.deepEqual(assetWithProof.creatorsRaw, []);
+  t.is(
+    assetWithProof.currentMetadata.sellerFeeBasisPoints,
+    SELLER_FEE_BASIS_POINTS_INHERIT
+  );
+  t.deepEqual(assetWithProof.currentMetadata.creators, []);
+});
+
 test('getAssetWithProof metadata can update inherited seller fee assets', async (t) => {
   // Given an empty Bubblegum tree.
   const umi = await createUmi();


### PR DESCRIPTION
After 
[#170](https://github.com/metaplex-foundation/mpl-bubblegum/pull/170), inherited SFBP assets needed a way to keep leaf values (sentinel 65535 / empty creators) for hashing and writes while exposing collection-resolved royalties for reads.
Main still relies on local sfbp_inherited typing, optional collection resolution, and data-hash guessing when DAS and leaf values diverge.
DAS now (soon) exposes first-class royalty.basis_points_raw, royalty.inherited, and creators_raw. This PR aligns Bubblegum with that shape and removes the fragile reconstruction path.


getAssetWithProof now returns:

`metadata` — DAS-resolved display fields
`currentMetadata` — canonical leaf metadata for write ixs / hashing (spread-friendly)
`sellerFeeBasisPointsRaw`? / `creatorsRaw`? — DAS _raw siblings
`inherited` — via DAS isInheritedSfbpRoyalty

Depends on @metaplex-foundation/digital-asset-standard-api@^2.1.0 (types + isInheritedSfbpRoyalty / inherit sentinel). we need to publish that DAS release before merging / refreshing the lockfile. https://github.com/metaplex-foundation/digital-asset-standard-api/pull/32

