### PR TITLE
chore: release JS client v5.1.0

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaplex-foundation/mpl-bubblegum",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "description": "Create and interact with compressed Metaplex NFTs",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Summary

- Bumps `clients/js/package.json` to `5.1.0` to match the version published to npm.
- [@metaplex-foundation/mpl-bubblegum@5.1.0](https://www.npmjs.com/package/@metaplex-foundation/mpl-bubblegum/v/5.1.0) was published successfully by the "Publish JS Client" workflow, but the workflow's automated release-PR step failed, so this PR applies the version bump manually.

The published release includes:
- Seller fee basis points / creators inheritance from MPL Core collections (#170)
- Re-exported generated `mintV2` helpers from the package root (#172)