### PR TITLE
Raise max in-transaction proof size from 17 to 30 for v1 transactions

### DIFF
--- a/programs/bubblegum/program/src/processor/create_tree.rs
+++ b/programs/bubblegum/program/src/processor/create_tree.rs
@@ -15,7 +15,17 @@ use crate::{
     state::{DecompressibleState, TreeConfig, TREE_AUTHORITY_SIZE},
 };
 
-pub const MAX_ACC_PROOFS_SIZE: u32 = 17;
+/// Maximum number of proof accounts allowed to travel in the transaction itself
+/// (i.e. the maximum uncovered proof path a tree may require beyond its canopy).
+///
+/// Historically 17: a legacy (1232-byte) transaction could only fit ~17 proof
+/// nodes as 32-byte account keys alongside the instruction's fixed accounts, so
+/// deeper trees required a canopy to remain operable (e.g. burnable).
+///
+/// With the v1 transaction format (SIMD-0296 / SIMD-0385: 4096-byte
+/// transactions, 64 inline accounts), a full proof for the deepest supported
+/// tree (depth 30) fits inline, so no supported tree needs a canopy.
+pub const MAX_ACC_PROOFS_SIZE: u32 = 30;
 
 #[derive(Accounts)]
 pub struct CreateTree<'info> {

--- a/programs/bubblegum/program/tests/simple.rs
+++ b/programs/bubblegum/program/tests/simple.rs
@@ -252,44 +252,41 @@ async fn test_create_public_tree_with_canopy() {
     assert!(cfg.is_public);
 }
 
+// With v1 transactions (SIMD-0296) a full proof for any supported tree depth
+// fits in the transaction, so trees deeper than the legacy 17-proof limit no
+// longer require a canopy.
 #[tokio::test]
-async fn test_cannot_create_tree_needing_too_many_proofs_with_too_small_canopy() {
+async fn test_create_tree_exceeding_legacy_proof_limit_with_small_canopy() {
     let context = BubblegumTestContext::new().await.unwrap();
+    let payer = context.payer();
 
-    let tree_create_result = context.create_tree_with_canopy::<19, 64>(1, true).await;
+    let mut tree = context
+        .create_tree_with_canopy::<19, 64>(1, true)
+        .await
+        .unwrap();
 
-    if let Err(err) = tree_create_result {
-        if let BanksClient(BanksClientError::TransactionError(e)) = *err {
-            assert_eq!(
-                e,
-                TransactionError::InstructionError(0, InstructionError::Custom(6041),)
-            );
-        } else {
-            panic!("Wrong variant");
-        }
-    } else {
-        panic!("Should have failed");
-    }
+    let cfg = tree.read_tree_config().await.unwrap();
+
+    assert_eq!(cfg.tree_creator, payer.pubkey());
+    assert_eq!(cfg.tree_delegate, payer.pubkey());
+    assert!(cfg.is_public);
 }
 
 #[tokio::test]
-async fn test_cannot_create_tree_needing_too_many_proofs_with_no_canopy() {
+async fn test_create_tree_exceeding_legacy_proof_limit_with_no_canopy() {
     let context = BubblegumTestContext::new().await.unwrap();
+    let payer = context.payer();
 
-    let tree_create_result = context.create_tree_with_canopy::<18, 64>(0, true).await;
+    let mut tree = context
+        .create_tree_with_canopy::<20, 64>(0, true)
+        .await
+        .unwrap();
 
-    if let Err(err) = tree_create_result {
-        if let BanksClient(BanksClientError::TransactionError(e)) = *err {
-            assert_eq!(
-                e,
-                TransactionError::InstructionError(0, InstructionError::Custom(6041),)
-            );
-        } else {
-            panic!("Wrong variant");
-        }
-    } else {
-        panic!("Should have failed");
-    }
+    let cfg = tree.read_tree_config().await.unwrap();
+
+    assert_eq!(cfg.tree_creator, payer.pubkey());
+    assert_eq!(cfg.tree_delegate, payer.pubkey());
+    assert!(cfg.is_public);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Prep for the v1 transaction format: bump `MAX_ACC_PROOFS_SIZE` from 17 to 30 so the `create_tree` canopy-size check no longer forces a canopy on deep trees.

The 17-proof limit existed because each proof node travels as a 32-byte account key, and a legacy 1,232-byte transaction could only fit ~17 of them alongside an instruction's fixed accounts — so deeper trees without a sufficient canopy could mint NFTs that were unburnable (the spam scenario this check guards against).

The v1 transaction format ([SIMD-0296](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0296-larger-transactions.md) / SIMD-0385) raises the transaction size to 4,096 bytes with 64 inline accounts. After `burn_v2`'s ~13 fixed accounts that leaves ~51 proof slots, comfortably covering the deepest tree spl-account-compression supports (depth 30). So with the limit at 30, every creatable tree is operable with zero canopy.

## Changes

- `MAX_ACC_PROOFS_SIZE`: 17 → 30, with a doc comment explaining both the legacy derivation and the v1 math.
- The two negative tests for the old limit (`19/canopy 1` and `18/canopy 0`) can no longer trigger, since no supported depth exceeds 30. They're replaced with positive tests covering depths beyond the legacy limit (`19/canopy 1` and `20/canopy 0`). The malformed-canopy error paths in `get_cached_path_length` are unaffected.

## Caveat

Until v1 transactions activate on mainnet (targeted with Agave v4.2) and clients adopt the format, a deep canopy-less tree is only operable via v1-format transactions — legacy-transaction clients won't be able to fit the proof. This PR is intentionally opened ahead of activation to prep; deployment timing is a release decision.

Validated with the CI toolchain (Rust 1.79.0): `cargo fmt --check`, `cargo clippy --all-targets --all-features --no-deps`, and `cargo check --tests` all pass. SBF integration tests will run in CI (Solana toolchain isn't installable in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Am4zCwoLUVRJcpaecnPUWX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Am4zCwoLUVRJcpaecnPUWX)_